### PR TITLE
AnimeBot.py Regex change for !stats tag search

### DIFF
--- a/roboragi/AnimeBot.py
+++ b/roboragi/AnimeBot.py
@@ -81,9 +81,9 @@ def start():
         #The "hasExpandedRequest" variable puts a stop on any other requests (since you can only have one expanded request in a comment)
         hasExpandedRequest = False
         
-        #This checks for requests.
-        #First up when check all known tags for the !stats request.
-        if re.search('\{{2}!stats\}{2}|(?<=(?<!\{)\{)!stats(?=\}(?!\}))|\<{2}!stats\>{2}|(?<=(?<!\<)\<)!stats(?=\>(?!\>))', comment.body, re.S) is not None
+        #This checks for requests. First up we check all known tags for the !stats request
+        # Assumes tag begins and ends with a whitespace OR at the string beginning/end
+        if re.search('(?<=^|\s)({!stats}|{{!stats}}|<!stats>|<<!stats>>)(?=$|\s)', comment.body, re.S) is not None
             commentReply = CommentBuilder.buildStatsComment(comment.subreddit)
         else:
 

--- a/roboragi/AnimeBot.py
+++ b/roboragi/AnimeBot.py
@@ -81,9 +81,9 @@ def start():
         #The "hasExpandedRequest" variable puts a stop on any other requests (since you can only have one expanded request in a comment)
         hasExpandedRequest = False
         
-        #This checks for requests. It's a little messy. Forgive me.
-        #First up when check all known tags for the !stats request. I know I could use a big regex statement for it. I'll have to change it at some point.
-        if (re.search('\{{2}!stats\}{2}', comment.body, re.S) is not None) or (re.search('(?<=(?<!\{)\{)!stats(?=\}(?!\}))', comment.body, re.S) is not None) or (re.search('\<{2}!stats\>{2}', comment.body, re.S) is not None) or (re.search('(?<=(?<!\<)\<)!stats(?=\>(?!\>))', comment.body, re.S) is not None):
+        #This checks for requests.
+        #First up when check all known tags for the !stats request.
+        if re.search('\{{2}!stats\}{2}|(?<=(?<!\{)\{)!stats(?=\}(?!\}))|\<{2}!stats\>{2}|(?<=(?<!\<)\<)!stats(?=\>(?!\>))', comment.body, re.S) is not None
             commentReply = CommentBuilder.buildStatsComment(comment.subreddit)
         else:
 


### PR DESCRIPTION
I made some changes to the regex that found and searched for !stats tags. Initially I just shrunk the code on that line down a bit. In making it clearer in my second commit (4656ca2e24f1a237b5f3b184787e0f7973d94d18) I also aimed to make it act differently. Before the following potentially undesirable cases would be matched and acted on:  
- <{!stats}>
- {{{!stats}}}}}
- kl{!stats}?

With the changes none of these cases are matched. Now a match requires either a string beginning (^) or white-space at the start of the pattern, and at its end a whitespace or the end ($). This does however have the possibly undesirable result of causing:
- This is a test <!stats>.
to fail due to the trailing period.

It should match any of (for either { or <):
- {{!stats}}
- blah {{!stats}}
- {{!stats}} test
- I run {!stats} now!
- {Bakemonogatari} {!stats} please.

I removed the literal strings from the > and < since they are never needed to my knowledge, and from { and } since they are treated as literal in most circumstances, except as qualifiers/repetition operators and within java [(link)](http://www.regular-expressions.info/characters.html)

Please let me know what you think :)