### PR TITLE
Replacement for manual XML unescaping

### DIFF
--- a/roboragi/MAL.py
+++ b/roboragi/MAL.py
@@ -1,26 +1,17 @@
 # -*- coding: utf-8 -*-
 
-'''
-Anilist.py
-Handles all of the connections to Anilist.
-'''
+"""
+MAL.py
+Handles all of the connections to MyAnimeList.
+"""
 
 import xml.etree.cElementTree as ET
 import requests
 import traceback
 import difflib
-import codecs
-import pprint
-
-MALUSER = ''
-MALPASSWORD = ''
-MALUSERAGENT = ''
-MALAUTH = ''
 
 try:
     import Config
-    MALUSER = Config.maluser
-    MALPASSWORD = Config.malpassword
     MALUSERAGENT = Config.maluseragent
     MALAUTH = Config.malauth
 except ImportError:
@@ -30,8 +21,7 @@ mal = requests.Session()
 
 #Sets up the connection to MAL.
 def setup():
-    mal_payload = {'username':MALUSER, 'password':MALPASSWORD, 'cookie':1, 'sublogin':'Login'}
-    mal.headers.update({'Authorization': MALAUTH, 'User-Agent':MALUSERAGENT})
+    mal.headers.update({'Authorization': MALAUTH, 'User-Agent': MALUSERAGENT})
 
 #Returns the closest anime (as a Json-like object) it can find using the given searchtext. MAL returns XML (bleh) so we have to convert it ourselves.
 def getAnimeDetails(searchText):
@@ -53,8 +43,8 @@ def getAnimeDetails(searchText):
             title_english = anime.find('english').text
 
             synonyms = None
-            if (anime.find('synonyms').text is not None):
-                synonyms = (anime.find('synonyms').text).split(";")
+            if anime.find('synonyms').text is not None:
+                synonyms = anime.find('synonyms').text.split(";")
 
             episodes = anime.find('episodes').text
             animeType = anime.find('type').text
@@ -65,16 +55,16 @@ def getAnimeDetails(searchText):
             image = anime.find('image').text
 
             data = {'id': animeID,
-                     'title': title,
-                     'english': title_english,
-                     'synonyms': synonyms,
-                     'episodes': episodes,
-                     'type': animeType,
-                     'status': status,
-                     'start_date': start_date,
-                     'end_date': end_date,
-                     'synopsis': synopsis,
-                     'image': image }
+                    'title': title,
+                    'english': title_english,
+                    'synonyms': synonyms,
+                    'episodes': episodes,
+                    'type': animeType,
+                    'status': status,
+                    'start_date': start_date,
+                    'end_date': end_date,
+                    'synopsis': synopsis,
+                    'image': image}
 
             animeList.append(data)
 
@@ -82,7 +72,7 @@ def getAnimeDetails(searchText):
 
         return closestAnime
         
-    except Exception as e:
+    except Exception:
         #traceback.print_exc()
         return None
 
@@ -94,7 +84,7 @@ def getClosestAnime(searchText, animeList):
         for anime in animeList:
             nameList.append(anime['title'].lower())
 
-            if not (anime['english'] is None):
+            if anime['english'] is not None:
                 nameList.append(anime['english'].lower())
 
             if anime['synonyms']:
@@ -112,17 +102,14 @@ def getClosestAnime(searchText, animeList):
                         return anime
 
         return None
-    except Exception as e:
+    except Exception:
         #traceback.print_exc()
         return None
 
-#MAL's XML is a piece of crap. There has to be a better way to do this.
+#MAL's XML is a piece of crap.
 def convertShittyXML(text):
-    text = text.replace('&Eacute;', 'É').replace('&times;', 'x').replace('&rsquo;', "'").replace('&lsquo;', "'").replace('&hellip', '...').replace('&le', '<').replace('<;', '; ').replace('&hearts;', '♥').replace('&mdash;', '-')
-    text = text.replace('&eacute;', 'é').replace('&ndash;', '-').replace('&Aacute;', 'Á').replace('&acute;', 'à').replace('&ldquo;', '"').replace('&rdquo;', '"').replace('&Oslash;', 'Ø').replace('&frac12;', '½').replace('&infin;', '∞')
-    text = text.replace('&agrave;', 'à').replace('&egrave;', 'è').replace('&dagger;', '†').replace('&sup2;', '²')
-    
-    return text
+    import HTMLParser
+    return HTMLParser.HTMLParser().unescape(text)
 
 #Used to check if two descriptions are relatively close. This is used in place of author searching because MAL don't give authors at any point.
 def getClosestFromDescription(mangaList, descriptionToCheck):
@@ -134,7 +121,7 @@ def getClosestFromDescription(mangaList, descriptionToCheck):
         closestNameFromList = difflib.get_close_matches(descriptionToCheck.lower(), descList, 1, 0.1)[0]
 
         for manga in mangaList:
-            if (closestNameFromList == manga['synopsis'].lower()):
+            if closestNameFromList == manga['synopsis'].lower():
                 return manga
         
     except:
@@ -160,8 +147,8 @@ def getMangaCloseToDescription(searchText, descriptionToCheck):
             title_english = manga.find('english').text
 
             synonyms = None
-            if not (manga.find('synonyms').text is None):
-                synonyms = (manga.find('synonyms').text).split(";")
+            if manga.find('synonyms').text is not None:
+                synonyms = manga.find('synonyms').text.split(";")
 
             chapters = manga.find('chapters').text
             volumes = manga.find('volumes').text
@@ -173,25 +160,23 @@ def getMangaCloseToDescription(searchText, descriptionToCheck):
             image = manga.find('image').text
 
             data = {'id': mangaID,
-                     'title': title,
-                     'english': title_english,
-                     'synonyms': synonyms,
-                     'chapters': chapters,
-                     'volumes': volumes,
-                     'type': mangaType,
-                     'status': status,
-                     'start_date': start_date,
-                     'end_date': end_date,
-                     'synopsis': synopsis,
-                     'image': image }
+                    'title': title,
+                    'english': title_english,
+                    'synonyms': synonyms,
+                    'chapters': chapters,
+                    'volumes': volumes,
+                    'type': mangaType,
+                    'status': status,
+                    'start_date': start_date,
+                    'end_date': end_date,
+                    'synopsis': synopsis,
+                    'image': image}
 
             mangaList.append(data)
 
         closeManga = getListOfCloseManga(searchText, mangaList)
 
         return getClosestFromDescription(closeManga, descriptionToCheck)
-
-        return None
     except:
         traceback.print_exc()
         return None
@@ -217,8 +202,8 @@ def getMangaDetails(searchText):
             title_english = manga.find('english').text
 
             synonyms = None
-            if not (manga.find('synonyms').text is None):
-                synonyms = (manga.find('synonyms').text).split(";")
+            if manga.find('synonyms').text is not None:
+                synonyms = manga.find('synonyms').text.split(";")
 
             chapters = manga.find('chapters').text
             volumes = manga.find('volumes').text
@@ -246,7 +231,7 @@ def getMangaDetails(searchText):
 
         closestManga = getClosestManga(searchText, mangaList)
 
-        if not (closestManga is None):
+        if closestManga is not None:
             return closestManga
         else:
             return None
@@ -264,10 +249,10 @@ def getListOfCloseManga(searchText, mangaList):
         for manga in mangaList:          
             if round(difflib.SequenceMatcher(lambda x: x == "", manga['title'].lower(), searchText.lower()).ratio(), 3) >= ratio:
                 returnList.append(manga)
-            elif not (manga['english'] is None):
+            elif manga['english'] is not None:
                 if round(difflib.SequenceMatcher(lambda x: x == "", manga['english'].lower(), searchText.lower()).ratio(), 3) >= ratio:
                     returnList.append(manga)
-            elif not (manga['synonyms'] is None):
+            elif manga['synonyms'] is not None:
                 for synonym in manga['synonyms']:
                     if round(difflib.SequenceMatcher(lambda x: x == "", synonym, searchText.lower()).ratio(), 3) >= ratio:
                         returnList.append(manga)
@@ -275,7 +260,7 @@ def getListOfCloseManga(searchText, mangaList):
 
         return returnList
         
-    except Exception as e:
+    except Exception:
         #traceback.print_exc()
         return None
 
@@ -287,30 +272,30 @@ def getClosestManga(searchText, mangaList):
         for manga in mangaList:
             nameList.append(manga['title'].lower())
             
-            if not (manga['english'] is None):
+            if manga['english'] is not None:
                 nameList.append(manga['english'].lower())
                 
-            if not (manga['synonyms'] is None):
+            if manga['synonyms'] is not None:
                 for synonym in manga['synonyms']:
                     nameList.append(synonym.lower().strip())
         
         closestNameFromList = difflib.get_close_matches(searchText.lower(), nameList, 1, 0.90)[0]
 
         for manga in mangaList:
-            if (manga['title'].lower() == closestNameFromList.lower()):
+            if manga['title'].lower() == closestNameFromList.lower():
                 return manga
-            elif not (manga['english'] is None):
-                if (manga['english'].lower() == closestNameFromList.lower()):
+            elif manga['english'] is not None:
+                if manga['english'].lower() == closestNameFromList.lower():
                     return manga
 
         for manga in mangaList:
-            if not (manga['synonyms'] is None):
+            if manga['synonyms'] is not None:
                 for synonym in manga['synonyms']:
                     if synonym.lower().strip() == closestNameFromList.lower():
                         return manga
 
         return None
-    except Exception as e:
+    except Exception:
         #traceback.print_exc()
         return None
 


### PR DESCRIPTION
I replaced the manual XML unescaping with HTMLParser.HTMLParser().unescape(…) from the standard lib which is probably a more easily maintainable solution (e.g. no further need to add new string replace calls manually for every new character found in the XML response).

I also made a some formatting and idiomatic fixes and removed a few unused variables, fields and imports.