### PR TITLE
Make Anilist.py more PEP8 compliant

### DIFF
--- a/roboragi/Anilist.py
+++ b/roboragi/Anilist.py
@@ -110,26 +110,29 @@ def morph_to_v1(raw):
 
     for raw_result in raw_results:
         try:
-            morphed = {}
-            morphed["id"] = raw_result["id"]
-            morphed["id_mal"] = raw_result["idMal"]
-            morphed["title_romaji"] = raw_result["title"]["romaji"]
-            morphed["title_english"] = raw_result["title"]["english"]
-            morphed["title_japanese"] = raw_result["title"]["native"]
-            morphed["type"] = map_media_format(raw_result["format"])
-            morphed["start_date_fuzzy"] = raw_result["startDate"]["year"]
-            morphed["end_date_fuzzy"] = raw_result["endDate"]["year"]
-            morphed["description"] = raw_result["description"]
-            morphed["genres"] = raw_result["genres"]
-            morphed["synonyms"] = raw_result["synonyms"]
-            morphed["total_episodes"] = raw_result["episodes"]
-            morphed["total_chapters"] = raw_result["chapters"]
-            morphed["total_volumes"] = raw_result["volumes"]
-            morphed["airing_status"] = map_media_status(raw_result["status"])
-            morphed["publishing_status"] = map_media_status(raw_result["status"])
-            morphed["airing"] = {"countdown": raw_result["nextAiringEpisode"]["timeUntilAiring"],
-                                 "next_episode": raw_result["nextAiringEpisode"]["episode"]} if raw_result[
-                "nextAiringEpisode"] else None
+            airing = dict(
+                countdown=raw_result["nextAiringEpisode"]["timeUntilAiring"],
+                next_episode=raw_result["nextAiringEpisode"]["episode"],
+            ) if raw_result["nextAiringEpisode"] else None
+            morphed = dict(
+                id=raw_result["id"],
+                id_mal=raw_result["idMal"],
+                title_romaji=raw_result["title"]["romaji"],
+                title_english=raw_result["title"]["english"],
+                title_japanese=raw_result["title"]["native"],
+                type=map_media_format(raw_result["format"]),
+                start_date_fuzzy=raw_result["startDate"]["year"],
+                end_date_fuzzy=raw_result["endDate"]["year"],
+                description=raw_result["description"],
+                genres=raw_result["genres"],
+                synonyms=raw_result["synonyms"],
+                total_episodes=raw_result["episodes"],
+                total_chapters=raw_result["chapters"],
+                total_volumes=raw_result["volumes"],
+                airing_status=map_media_status(raw_result["status"]),
+                publishing_status=map_media_status(raw_result["status"]),
+                airing=airing,
+            )
 
             morphed_results.append(morphed)
         except Exception as e:
@@ -166,14 +169,14 @@ def map_media_status(media_status):
 
 def getSynonyms(request):
     synonyms = []
-    synonyms.extend(request['synonyms']) if request['synonyms'] else None
+    synonyms.extend(request.get('synonyms'))
     return synonyms
 
 
 def getTitles(request):
     titles = []
-    titles.append(request['title_english']) if request['title_english'] else None
-    titles.append(request['title_romaji']) if request['title_romaji'] else None
+    titles.append(request.get('title_english'))
+    titles.append(request.get('title_romaji'))
     return titles
 
 
@@ -184,12 +187,13 @@ def detailsBySearch(searchText, mediaType):
             'type': mediaType
         }
 
-        request = req.post(uri, json={'query': search_query, 'variables': search_variables})
+        payload = {'query': search_query, 'variables': search_variables}
+        request = req.post(uri, json=payload)
         req.close()
 
         return morph_to_v1(request.json())
 
-    except Exception as e:
+    except Exception:
         traceback.print_exc()
         req.close()
         return None
@@ -201,23 +205,28 @@ def detailsById(idToFind):
             'id': int(idToFind)
         }
 
-        request = req.post(uri, json={'query': id_query, 'variables': id_variables})
+        payload = {'query': id_query, 'variables': id_variables}
+        request = req.post(uri, json=payload)
         req.close()
 
         return morph_to_v1(request.json())[0]
 
-    except Exception as e:
+    except Exception:
         traceback.print_exc()
         req.close()
         return None
 
 
-# Returns the closest anime (as a Json-like object) it can find using the given searchtext
 def getAnimeDetails(searchText):
+    """
+    Returns the closest anime (as a Json-like object) it can find using the
+    given searchtext
+    """
     try:
         results = detailsBySearch(searchText, 'ANIME')
 
-        # Of the given list of shows, we try to find the one we think is closest to our search term
+        # Of the given list of shows, we try to find the one we think is
+        # closest to our search term
         closest_anime = getClosestAnime(searchText, results)
 
         if closest_anime:
@@ -225,29 +234,36 @@ def getAnimeDetails(searchText):
         else:
             return None
 
-    except Exception as e:
+    except Exception:
         traceback.print_exc()
         req.close()
         return None
 
 
-# Returns the anime details based on an id
 def getAnimeDetailsById(animeID):
+    """
+    Returns the anime details based on an id
+    """
     try:
         return detailsById(animeID)
-    except Exception as e:
+    except Exception:
         return None
 
 
-# Given a list, it finds the closest anime series it can.
 def getClosestAnime(searchText, animeList):
+    """
+    Given a list, it finds the closest anime series it can.
+    """
     try:
         animeNameList = []
         animeNameListNoSyn = []
 
-        # For each anime series, add all the titles/synonyms to an array and do a fuzzy string search to find the one
-        # closest to our search text.  We also fill out an array that doesn't contain the synonyms. This is to protect
-        # against shows with multiple adaptations and similar synonyms (e.g. Haiyore Nyaruko-San)
+        # For each anime series, add all the titles/synonyms to an array and
+        # do a fuzzy string search to find the one
+        # closest to our search text.  We also fill out an array that doesn't
+        # contain the synonyms. This is to protect
+        # against shows with multiple adaptations and similar synonyms
+        # (e.g. Haiyore Nyaruko-San)
         for anime in animeList:
             if 'title_english' in anime and anime['title_english']:
                 animeNameList.append(anime['title_english'].lower())
@@ -262,24 +278,34 @@ def getClosestAnime(searchText, animeList):
                     animeNameList.append(synonym.lower())
 
         try:
-            closestNameFromList = difflib.get_close_matches(searchText.lower(), animeNameList, 1, 0.95)[0]
-        except:
+            matches = difflib.get_close_matches(
+                word=searchText.lower(),
+                possibilities=animeNameList,
+                n=1,
+                cutoff=0.95,
+            )
+            closestNameFromList = matches[0]
+        except Exception:
             closestNameFromList = None
 
         if closestNameFromList:
+            closestNameFromList = closestNameFromList.lower()
             for anime in animeList:
-                if anime['title_english'] and anime['title_english'].lower() == closestNameFromList.lower():
+                title_english = anime.get('title_english', '').lower()
+                title_romaji = anime.get('title_english', '').lower()
+                if title_english == closestNameFromList:
                     return anime
-                elif anime['title_romaji'] and anime['title_romaji'].lower() == closestNameFromList.lower():
+                elif title_romaji == closestNameFromList:
                     return anime
                 else:
                     for synonym in anime['synonyms']:
-                        if (synonym.lower() == closestNameFromList.lower()) and (
-                                synonym.lower() not in animeNameListNoSyn):
+                        synonym = synonym.lower()
+                        if (synonym == closestNameFromList) and (
+                                synonym not in animeNameListNoSyn):
                             return anime
 
         return None
-    except:
+    except Exception:
         traceback.print_exc()
         return None
 
@@ -288,8 +314,10 @@ def getLightNovelDetails(searchText):
     return getMangaDetails(searchText, True)
 
 
-# Returns the closest manga series given a specific search term
 def getMangaDetails(searchText, isLN=False):
+    """
+    Returns the closest manga series given a specific search term
+    """
     try:
         results = detailsBySearch(searchText, 'MANGA')
 
@@ -304,16 +332,20 @@ def getMangaDetails(searchText, isLN=False):
         return None
 
 
-# Returns the closest manga series given an id
 def getMangaDetailsById(mangaId):
+    """
+    Returns the closest manga series given an id
+    """
     try:
         return detailsById(mangaId)
     except Exception:
         return None
 
 
-# Used to determine the closest manga to a given search term in a list
 def getClosestManga(searchText, mangaList, isLN=False):
+    """
+    Used to determine the closest manga to a given search term in a list
+    """
     try:
         mangaNameList = []
 
@@ -324,31 +356,42 @@ def getClosestManga(searchText, mangaList, isLN=False):
                 mangaList.remove(manga)
 
         for manga in mangaList:
-            mangaNameList.append(manga['title_english'].lower()) if manga['title_english'] else None
-            mangaNameList.append(manga['title_romaji'].lower()) if manga['title_romaji'] else None
+            title_english = manga.get('title_english', '').lower() or None
+            title_romaji = manga.get('title_romaji', '').lower() or None
+            mangaNameList.append(title_english)
+            mangaNameList.append(title_romaji)
 
             for synonym in manga['synonyms']:
                 mangaNameList.append(synonym.lower())
 
         try:
-            closestNameFromList = difflib.get_close_matches(searchText.lower(), mangaNameList, 1, 0.90)[0]
-        except:
+            matches = difflib.get_close_matches(
+                word=searchText.lower(),
+                possibilities=mangaNameList,
+                n=1,
+                cutoff=0.90,
+            )
+            closestNameFromList = matches[0]
+        except Exception:
             closestNameFromList = None
 
         if closestNameFromList:
+            closestNameFromList = closestNameFromList.lower()
             for manga in mangaList:
                 if not ('one shot' in manga['type'].lower()):
-                    if manga['title_english'] and (manga['title_english'].lower() == closestNameFromList.lower()):
+                    title_english = manga.get('title_english', '').lower()
+                    title_romaji = manga.get('title_english', '').lower()
+                    if title_english == closestNameFromList:
                         return manga
-                    if manga['title_romaji'] and (manga['title_romaji'].lower() == closestNameFromList.lower()):
+                    if title_romaji == closestNameFromList:
                         return manga
 
             for manga in mangaList:
                 for synonym in manga['synonyms']:
-                    if synonym.lower() == closestNameFromList.lower():
+                    if synonym.lower() == closestNameFromList:
                         return manga
 
         return None
-    except Exception as e:
+    except Exception:
         traceback.print_exc()
         return None


### PR DESCRIPTION
This will reduce the number of PEP8 violations (according to `flake8`) from 23 to 0. This is one small step towards resolving #16.

In order to keep the changeset small I just did what I could to get rid of the strict violations. I'll probably
go through and do another pass later in order to fix unconventional style (i.e. `detailsBySearch` -> `details_by_search`).

This PR doesn't do anything to improve the logic (reduce McCabe complexity, etc.). That's another task I'd like to save for a later PR in order to make it easier to review these changes.

```bash
(roboragi) [17:41:54] tucker@khanti:~/Projects/Roboragi git:(master) $ flake8 roboragi/Anilist.py        
roboragi/Anilist.py:129:80: E501 line too long (81 > 79 characters)
roboragi/Anilist.py:130:80: E501 line too long (97 > 79 characters)
roboragi/Anilist.py:131:80: E501 line too long (107 > 79 characters)
roboragi/Anilist.py:175:80: E501 line too long (81 > 79 characters)
roboragi/Anilist.py:187:80: E501 line too long (92 > 79 characters)
roboragi/Anilist.py:204:80: E501 line too long (84 > 79 characters)
roboragi/Anilist.py:215:80: E501 line too long (90 > 79 characters)
roboragi/Anilist.py:220:80: E501 line too long (99 > 79 characters)
roboragi/Anilist.py:248:80: E501 line too long (117 > 79 characters)
roboragi/Anilist.py:249:80: E501 line too long (118 > 79 characters)
roboragi/Anilist.py:250:80: E501 line too long (97 > 79 characters)
roboragi/Anilist.py:265:80: E501 line too long (106 > 79 characters)
roboragi/Anilist.py:266:9: E722 do not use bare except'
roboragi/Anilist.py:271:80: E501 line too long (108 > 79 characters)
roboragi/Anilist.py:273:80: E501 line too long (108 > 79 characters)
roboragi/Anilist.py:277:80: E501 line too long (81 > 79 characters)
roboragi/Anilist.py:282:5: E722 do not use bare except'
roboragi/Anilist.py:327:80: E501 line too long (100 > 79 characters)
roboragi/Anilist.py:328:80: E501 line too long (98 > 79 characters)
roboragi/Anilist.py:334:80: E501 line too long (106 > 79 characters)
roboragi/Anilist.py:335:9: E722 do not use bare except'
roboragi/Anilist.py:341:80: E501 line too long (114 > 79 characters)
roboragi/Anilist.py:343:80: E501 line too long (112 > 79 characters)
(roboragi) [17:41:57] tucker@khanti:~/Projects/Roboragi git:(master) $ git co pep8-compliance
Switched to branch 'pep8-compliance'
Your branch is up to date with 'origin/pep8-compliance'.
(roboragi) [17:42:01] tucker@khanti:~/Projects/Roboragi git:(pep8-compliance) $ flake8 roboragi/Anilist.py
(roboragi) [17:42:05] tucker@khanti:~/Projects/Roboragi git:(pep8-compliance) $
```