### PR TITLE
Fixing mixed space and tab error in Anilist.py to comply with PEP8

### DIFF
--- a/roboragi/Anilist.py
+++ b/roboragi/Anilist.py
@@ -359,9 +359,9 @@ def getClosestManga(searchText, mangaList, isLN=False):
             title_english = manga.get('title_english')
             title_romaji = manga.get('title_romaji')
             if title_english:
-            	mangaNameList.append(title_english.lower())
+                mangaNameList.append(title_english.lower())
             if title_romaji:
-            	mangaNameList.append(title_romaji.lower())
+                mangaNameList.append(title_romaji.lower())
 
             for synonym in manga['synonyms']:
                 mangaNameList.append(synonym.lower())


### PR DESCRIPTION
Really low fruit, fixing PEP8 indentation issues in Anilist.py 

```
[ecramer@sputnik roboragi] $ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
[ecramer@sputnik roboragi] $ flake8 Anilist.py 
Anilist.py:362:13: E101 indentation contains mixed spaces and tabs
Anilist.py:362:13: W191 indentation contains tabs
Anilist.py:364:13: E101 indentation contains mixed spaces and tabs
Anilist.py:364:13: W191 indentation contains tabs
[ecramer@sputnik roboragi] $ git checkout pep8-anilist-handler 
Switched to branch 'pep8-anilist-handler'
Your branch is up to date with 'origin/pep8-anilist-handler'.
[ecramer@sputnik roboragi] $ flake8 Anilist.py 
[ecramer@sputnik roboragi] $ 
```