### PR TITLE
Make Kitsu.py more PEP8 compliant

### DIFF
--- a/tests/test_kitsu.py
+++ b/tests/test_kitsu.py
@@ -17,6 +17,7 @@ import pytest
 
 from roboragi.Kitsu import (
     get_synonyms,
+    get_titles,
     get_title_by_language_codes,
     ENGLISH_LANGUAGE_CODES,
     ROMAJI_LANGUAGE_CODES,
@@ -47,6 +48,43 @@ def test_get_synonyms_dedupes_synonyms():
     expected = set(('Samurai Champloo', 'One Punch Man'))
 
     assert get_synonyms(result=given) == expected
+
+
+def test_get_titles_dedupes_titles():
+    given = dict(
+        title_english='Samurai Champloo',
+        title_romaji='Samurai Champloo',
+    )
+    expected = set(('Samurai Champloo',))
+
+    assert get_titles(result=given) == expected
+
+
+def test_get_titles_can_ignore_missing_english_titles():
+    given = dict(
+        title_english=None,
+        title_romaji='Samurai Champloo'
+    )
+    expected = set(('Samurai Champloo',))
+
+    assert get_titles(result=given) == expected
+
+
+def test_get_titles_can_ignore_missing_romaji_titles():
+    given = dict(
+        title_english='Samurai Champloo',
+        title_romaji=None,
+    )
+    expected = set(('Samurai Champloo',))
+
+    assert get_titles(result=given) == expected
+
+
+def test_get_titles_returns_empty_set_with_no_titles():
+    given = dict(title_english=None, title_romaji=None)
+    expected = set()
+
+    assert get_titles(result=given) == expected
 
 
 @pytest.mark.parametrize('language_codes,titles,expected', [

--- a/tests/test_kitsu.py
+++ b/tests/test_kitsu.py
@@ -16,6 +16,7 @@
 import pytest
 
 from roboragi.Kitsu import (
+    get_synonyms,
     get_title_by_language_codes,
     ENGLISH_LANGUAGE_CODES,
     ROMAJI_LANGUAGE_CODES,
@@ -34,6 +35,18 @@ ALL_LANGUAGE_TITLES = dict(
     **ROMAJI_TITLES,
     **JAPANESE_TITLES,
 )
+
+
+def test_get_synonyms_dedupes_synonyms():
+    given = dict(synonyms=[
+        'Samurai Champloo',
+        'Samurai Champloo',
+        'One Punch Man',
+        'One Punch Man'
+    ])
+    expected = set(('Samurai Champloo', 'One Punch Man'))
+
+    assert get_synonyms(result=given) == expected
 
 
 @pytest.mark.parametrize('language_codes,titles,expected', [

--- a/tests/test_kitsu.py
+++ b/tests/test_kitsu.py
@@ -15,23 +15,61 @@
 
 import pytest
 
-from roboragi.Kitsu import get_title_by_language_codes, ENGLISH_LANGUAGE_CODES, ROMAJI_LANGUAGE_CODES, JAPANESE_LANGUAGE_CODES
+from roboragi.Kitsu import (
+    get_title_by_language_codes,
+    ENGLISH_LANGUAGE_CODES,
+    ROMAJI_LANGUAGE_CODES,
+    JAPANESE_LANGUAGE_CODES
+)
+
+BRITISH_ENGLISH_TITLES = dict(en='British English Title')
+AMERICAN_ENGLISH_TITLES = dict(en_us='American English Title')
+ALL_ENGLISH_TITLES = dict(**BRITISH_ENGLISH_TITLES, **AMERICAN_ENGLISH_TITLES)
+
+ROMAJI_TITLES = dict(en_jp='Rōmaji Title')
+JAPANESE_TITLES = dict(ja_jp='日本のタイトル')
+
+ALL_LANGUAGE_TITLES = dict(
+    **ALL_ENGLISH_TITLES,
+    **ROMAJI_TITLES,
+    **JAPANESE_TITLES,
+)
 
 
 @pytest.mark.parametrize('language_codes,titles,expected', [
-    (ENGLISH_LANGUAGE_CODES, {'en': 'English'}, 'English'),
-    (ENGLISH_LANGUAGE_CODES, {'en_us': 'American English'}, 'American English'),
-    (ROMAJI_LANGUAGE_CODES, {'en_jp': 'Romaji'}, 'Romaji'),
-    (JAPANESE_LANGUAGE_CODES, {'ja_jp': 'Japanese'}, 'Japanese'),
-    (ENGLISH_LANGUAGE_CODES, {'en': 'English', 'en_us': 'American English'}, 'English'),
-    (ENGLISH_LANGUAGE_CODES, {'en': 'English', 'en_us': 'American English', 'en_jp': 'Romaji', 'ja_jp': 'Japanese'}, 'English'),
-    (ROMAJI_LANGUAGE_CODES, {'en': 'English', 'en_us': 'American English', 'en_jp': 'Romaji', 'ja_jp': 'Japanese'}, 'Romaji'),
-    (JAPANESE_LANGUAGE_CODES, {'en': 'English', 'en_us': 'American English', 'en_jp': 'Romaji', 'ja_jp': 'Japanese'}, 'Japanese'),
-    (ENGLISH_LANGUAGE_CODES, {}, None),
-    (ROMAJI_LANGUAGE_CODES, {}, None),
-    (JAPANESE_LANGUAGE_CODES, {}, None),
+    (ENGLISH_LANGUAGE_CODES, BRITISH_ENGLISH_TITLES, BRITISH_ENGLISH_TITLES['en']),  # noqa: E501
+    (ENGLISH_LANGUAGE_CODES, AMERICAN_ENGLISH_TITLES, AMERICAN_ENGLISH_TITLES['en_us']),  # noqa: E501
+    (ROMAJI_LANGUAGE_CODES, ROMAJI_TITLES, ROMAJI_TITLES['en_jp']),
+    (JAPANESE_LANGUAGE_CODES, JAPANESE_TITLES, JAPANESE_TITLES['ja_jp']),
 ])
-def test_title_extraction(language_codes, titles, expected):
+def test_title_extraction_single_titles(language_codes, titles, expected):
     actual = get_title_by_language_codes(titles, language_codes)
     assert actual == expected
 
+
+@pytest.mark.parametrize('language_codes,titles,expected', [
+    (ENGLISH_LANGUAGE_CODES, ALL_LANGUAGE_TITLES, ALL_LANGUAGE_TITLES['en']),
+    (ROMAJI_LANGUAGE_CODES, ALL_LANGUAGE_TITLES, ALL_LANGUAGE_TITLES['en_jp']),
+    (JAPANESE_LANGUAGE_CODES, ALL_LANGUAGE_TITLES, ALL_LANGUAGE_TITLES['ja_jp']),  # noqa: E501
+])
+def test_title_extraction_multiple_titles(language_codes, titles, expected):
+    actual = get_title_by_language_codes(titles, language_codes)
+    assert actual == expected
+
+
+@pytest.mark.parametrize('language_codes', [
+    ENGLISH_LANGUAGE_CODES,
+    ROMAJI_LANGUAGE_CODES,
+    JAPANESE_LANGUAGE_CODES,
+])
+def test_title_extraction_no_titles(language_codes):
+    assert get_title_by_language_codes({}, language_codes) is None
+
+
+def test_title_extraction_prefers_british_over_american_english():
+    expected = ALL_ENGLISH_TITLES['en']
+    actual = get_title_by_language_codes(
+        titles=ALL_ENGLISH_TITLES,
+        language_codes=ENGLISH_LANGUAGE_CODES
+    )
+    assert actual == expected


### PR DESCRIPTION
This PR makes `roboragi/Kitsu.py` PEP 8 compliant. It also tweaks the existing tests a little bit, but doesn't add much in the way of coverage. I think that should be handled by a separate PR during refactoring.

```
(roboragi) [11:11:36] tucker@khanti:~/Projects/Roboragi git:(master) $ flake8 roboragi/Kitsu.py
roboragi/Kitsu.py:32:80: E501 line too long (100 > 79 characters)
roboragi/Kitsu.py:60:80: E501 line too long (95 > 79 characters)
roboragi/Kitsu.py:64:80: E501 line too long (98 > 79 characters)
roboragi/Kitsu.py:68:80: E501 line too long (80 > 79 characters)
roboragi/Kitsu.py:71:80: E501 line too long (81 > 79 characters)
roboragi/Kitsu.py:94:5: E722 do not use bare except'
roboragi/Kitsu.py:101:5: E722 do not use bare except'
roboragi/Kitsu.py:108:5: E722 do not use bare except'
roboragi/Kitsu.py:118:80: E501 line too long (95 > 79 characters)
roboragi/Kitsu.py:119:80: E501 line too long (130 > 79 characters)
roboragi/Kitsu.py:120:80: E501 line too long (132 > 79 characters)
roboragi/Kitsu.py:121:80: E501 line too long (134 > 79 characters)
roboragi/Kitsu.py:122:80: E501 line too long (145 > 79 characters)
roboragi/Kitsu.py:123:80: E501 line too long (141 > 79 characters)
roboragi/Kitsu.py:139:80: E501 line too long (85 > 79 characters)
roboragi/Kitsu.py:140:80: E501 line too long (120 > 79 characters)
roboragi/Kitsu.py:141:80: E501 line too long (122 > 79 characters)
roboragi/Kitsu.py:142:80: E501 line too long (135 > 79 characters)
roboragi/Kitsu.py:143:80: E501 line too long (128 > 79 characters)
roboragi/Kitsu.py:144:80: E501 line too long (131 > 79 characters)
roboragi/Kitsu.py:162:80: E501 line too long (82 > 79 characters)
roboragi/Kitsu.py:163:80: E501 line too long (117 > 79 characters)
roboragi/Kitsu.py:164:80: E501 line too long (119 > 79 characters)
roboragi/Kitsu.py:165:80: E501 line too long (132 > 79 characters)
roboragi/Kitsu.py:166:80: E501 line too long (125 > 79 characters)
roboragi/Kitsu.py:167:80: E501 line too long (128 > 79 characters)
(roboragi) [11:11:38] tucker@khanti:~/Projects/Roboragi git:(master) $ git co pep8-kitsu
Switched to branch 'pep8-kitsu'
Your branch is up to date with 'origin/pep8-kitsu'.
(roboragi) [11:11:43] tucker@khanti:~/Projects/Roboragi git:(pep8-kitsu) $ flake8 roboragi/Kitsu.py
(roboragi) [11:11:46] tucker@khanti:~/Projects/Roboragi git:(pep8-kitsu) $
```