### PR TITLE
Make LNDB.py more PEP8 compliant

### DIFF
--- a/roboragi/LNDB.py
+++ b/roboragi/LNDB.py
@@ -29,7 +29,10 @@ req = requests.Session()
 def getLightNovelURL(searchText):
     try:
         searchText = searchText.replace(' ', '+')
-        html = req.get('http://lndb.info/search?text=' + searchText, timeout=10)
+        html = req.get(
+            url=f"http://lndb.info/search?text={searchText}",
+            timeout=10
+        )
         req.close()
 
         lndb = pq(html.text)
@@ -54,7 +57,7 @@ def getLightNovelURL(searchText):
             closest = findClosestLightNovel(searchText, lnList)
             return closest['url']
 
-    except Exception as e:
+    except Exception:
         req.close()
         return None
 
@@ -66,14 +69,19 @@ def findClosestLightNovel(searchText, lnList):
         for ln in lnList:
             nameList.append(ln['title'].lower())
 
-        closestNameFromList = difflib.get_close_matches(searchText.lower(), nameList, 1, 0.80)
+        closestNameFromList = difflib.get_close_matches(
+            word=searchText.lower(),
+            possibilities=nameList,
+            n=1,
+            cutoff=0.80
+        )
 
         for ln in lnList:
             if ln['title'].lower() == closestNameFromList[0].lower():
                 return ln
 
         return None
-    except:
+    except Exception:
         return None
 
 


### PR DESCRIPTION
This PR makes `roboragi/LNDB.py` more PEP8 compliant.

```
(roboragi) [11:29:21] tucker@khanti:~/Projects/Roboragi git:(master) $ flake8 roboragi/LNDB.py 
roboragi/LNDB.py:32:80: E501 line too long (80 > 79 characters)
roboragi/LNDB.py:69:80: E501 line too long (94 > 79 characters)
roboragi/LNDB.py:76:5: E722 do not use bare except'
(roboragi) [11:29:26] tucker@khanti:~/Projects/Roboragi git:(master) $ git co pep8-lndb
Switched to branch 'pep8-lndb'
(roboragi) [11:29:32] tucker@khanti:~/Projects/Roboragi git:(pep8-lndb) $ flake8 roboragi/LNDB.py
(roboragi) [11:29:35] tucker@khanti:~/Projects/Roboragi git:(pep8-lndb) $
```