### PR TITLE
Make MU.py and NU.py more PEP8 compliant

### DIFF
--- a/roboragi/MU.py
+++ b/roboragi/MU.py
@@ -33,21 +33,30 @@ def findClosestManga(searchText, mangaList):
         for manga in mangaList:
             nameList.append(manga['title'].lower())
 
-        closestNameFromList = difflib.get_close_matches(searchText.lower(), nameList, 1, 0.85)
+        closestNameFromList = difflib.get_close_matches(
+            word=searchText.lower(),
+            possibilities=nameList,
+            n=1,
+            cutoff=0.85
+        )
 
         for manga in mangaList:
             if manga['title'].lower() == closestNameFromList[0].lower():
                 return manga
 
         return None
-    except:
+    except Exception:
         return None
 
 
 def getMangaURL(searchText):
     try:
         payload = {'search': searchText}
-        html = req.get('https://mangaupdates.com/series.html', params=payload, timeout=10)
+        html = req.get(
+            url='https://mangaupdates.com/series.html',
+            params=payload,
+            timeout=10
+        )
         req.close()
 
         mu = pq(html.text)
@@ -73,7 +82,7 @@ def getMangaURL(searchText):
         closest = findClosestManga(searchText, mangaList)
         return closest['url']
 
-    except:
+    except Exception:
         req.close()
         return None
 

--- a/roboragi/NU.py
+++ b/roboragi/NU.py
@@ -29,7 +29,10 @@ req = requests.Session()
 def getLightNovelURL(searchText):
     try:
         searchText = searchText.replace(' ', '+')
-        html = requests.get('http://www.novelupdates.com/?s=' + searchText, timeout=10)
+        html = requests.get(
+            url=f"http://www.novelupdates.com/?s={searchText}",
+            timeout=10
+        )
         req.close()
 
         nu = pq(html.text)
@@ -48,7 +51,7 @@ def getLightNovelURL(searchText):
         closest = findClosestLightNovel(searchText, lnList)
         return closest['url']
 
-    except:
+    except Exception:
         req.close()
         return None
 
@@ -64,8 +67,17 @@ def findClosestLightNovel(searchText, lnList):
             if '(wn)' not in ln['title'].lower():
                 nameListWithoutWN.append(ln['title'].lower())
 
-        closestNameFromListWithoutWN = difflib.get_close_matches(searchText.lower(), nameListWithoutWN, 1, 0.80)
-        closestNameFromListWithWN = difflib.get_close_matches(searchText.lower(), nameList, 1, 0.80)
+        closestNameFromListWithoutWN = difflib.get_close_matches(
+            word=searchText.lower(),
+            possibilities=nameListWithoutWN,
+            n=1,
+            cutoff=0.80
+        )
+        closestNameFromListWithWN = difflib.get_close_matches(
+            word=searchText.lower(), possibilities=nameList,
+            n=1,
+            cutoff=0.80
+        )
 
         if closestNameFromListWithoutWN:
             nameToUse = closestNameFromListWithoutWN[0].lower()
@@ -77,7 +89,7 @@ def findClosestLightNovel(searchText, lnList):
                 return ln
 
         return None
-    except:
+    except Exception:
         return None
 
 


### PR DESCRIPTION
This PR makes both `roboragi/MU.py` and `roboragi/NU.py` more PEP8 compliant. If I'd had the presence of mind I would actually have included #64 in this as well since they're all pretty trivial fixes.

```
(roboragi) [11:46:09] tucker@khanti:~/Projects/Roboragi git:(master) $ flake8 roboragi/MU.py roboragi/NU.py                                                                 
roboragi/MU.py:36:80: E501 line too long (94 > 79 characters)
roboragi/MU.py:43:5: E722 do not use bare except'
roboragi/MU.py:50:80: E501 line too long (90 > 79 characters)
roboragi/MU.py:76:5: E722 do not use bare except'
roboragi/NU.py:32:80: E501 line too long (87 > 79 characters)
roboragi/NU.py:51:5: E722 do not use bare except'
roboragi/NU.py:67:80: E501 line too long (112 > 79 characters)
roboragi/NU.py:68:80: E501 line too long (100 > 79 characters)
roboragi/NU.py:80:5: E722 do not use bare except'
(roboragi) [11:46:12] tucker@khanti:~/Projects/Roboragi git:(master) $ git co pep8-mu-nu                                                                                    
Switched to branch 'pep8-mu-nu'
Your branch is up to date with 'origin/pep8-mu-nu'.
(roboragi) [11:46:16] tucker@khanti:~/Projects/Roboragi git:(pep8-mu-nu) $ flake8 roboragi/MU.py roboragi/NU.py                                                             
(roboragi) [11:46:19] tucker@khanti:~/Projects/Roboragi git:(pep8-mu-nu) $
```