### PR TITLE
Make Reference.py more PEP8 compliant

### DIFF
--- a/roboragi/Reference.py
+++ b/roboragi/Reference.py
@@ -23,14 +23,15 @@ sqlCur = sqlConn.cursor()
 
 def is_april_fools_2016(username):
     try:
-        sqlCur.execute("SELECT 1 FROM aprilfools2016 WHERE username = ? LIMIT 1", [username])
+        query = "SELECT 1 FROM aprilfools2016 WHERE username = ? LIMIT 1"
+        sqlCur.execute(query, [username])
         result = sqlCur.fetchone()
 
         if result:
             return True
         else:
             return False
-    except Exception as e:
+    except Exception:
         return False
 
 


### PR DESCRIPTION
This PR makes `roboragi/Reference.py` more PEP8 compliant. I should definitely have included this in #65 as it's so trivial... :upside_down_face:

```
(roboragi) [12:15:16] tucker@khanti:~/Projects/Roboragi git:(master) $ flake8 roboragi/Reference.py
roboragi/Reference.py:26:80: E501 line too long (93 > 79 characters)
(roboragi) [12:15:18] tucker@khanti:~/Projects/Roboragi git:(master) $ git co pep8-reference
Switched to branch 'pep8-reference'
(roboragi) [12:15:21] tucker@khanti:~/Projects/Roboragi git:(pep8-reference) $ flake8 roboragi/Reference.py
(roboragi) [12:15:23] tucker@khanti:~/Projects/Roboragi git:(pep8-reference) $
```