### PR TITLE
Fix #73, blacken all the code

### DIFF
--- a/roboragi/Anilist.py
+++ b/roboragi/Anilist.py
@@ -25,9 +25,9 @@ import requests
 
 req = requests.Session()
 
-uri = 'https://graphql.anilist.co'
+uri = "https://graphql.anilist.co"
 
-search_query = '''query ($search: String, $type: MediaType) {
+search_query = """query ($search: String, $type: MediaType) {
   Page {
     media(search: $search, type: $type) {
       id
@@ -63,9 +63,9 @@ search_query = '''query ($search: String, $type: MediaType) {
       }
     }
   }
-}'''
+}"""
 
-id_query = '''query ($id: Int) {
+id_query = """query ($id: Int) {
   Page {
     media(id: $id) {
       id
@@ -101,7 +101,7 @@ id_query = '''query ($id: Int) {
       }
     }
   }
-}'''
+}"""
 
 
 def morph_to_v1(raw):
@@ -110,10 +110,14 @@ def morph_to_v1(raw):
 
     for raw_result in raw_results:
         try:
-            airing = dict(
-                countdown=raw_result["nextAiringEpisode"]["timeUntilAiring"],
-                next_episode=raw_result["nextAiringEpisode"]["episode"],
-            ) if raw_result["nextAiringEpisode"] else None
+            airing = (
+                dict(
+                    countdown=raw_result["nextAiringEpisode"]["timeUntilAiring"],
+                    next_episode=raw_result["nextAiringEpisode"]["episode"],
+                )
+                if raw_result["nextAiringEpisode"]
+                else None
+            )
             morphed = dict(
                 id=raw_result["id"],
                 id_mal=raw_result["idMal"],
@@ -143,51 +147,48 @@ def morph_to_v1(raw):
 
 def map_media_format(media_format):
     mapped_formats = {
-        'TV': 'TV',
-        'TV_SHORT': 'TV Short',
-        'MOVIE': 'Movie',
-        'SPECIAL': 'Special',
-        'OVA': 'OVA',
-        'ONA': 'ONA',
-        'MUSIC': 'Music',
-        'MANGA': 'Manga',
-        'NOVEL': 'Novel',
-        'ONE_SHOT': 'One Shot',
+        "TV": "TV",
+        "TV_SHORT": "TV Short",
+        "MOVIE": "Movie",
+        "SPECIAL": "Special",
+        "OVA": "OVA",
+        "ONA": "ONA",
+        "MUSIC": "Music",
+        "MANGA": "Manga",
+        "NOVEL": "Novel",
+        "ONE_SHOT": "One Shot",
     }
     return mapped_formats[media_format]
 
 
 def map_media_status(media_status):
     mapped_status = {
-        'FINISHED': 'Finished',
-        'RELEASING': 'Releasing',
-        'NOT_YET_RELEASED': 'Not Yet Released',
-        'CANCELLED': 'Special'
+        "FINISHED": "Finished",
+        "RELEASING": "Releasing",
+        "NOT_YET_RELEASED": "Not Yet Released",
+        "CANCELLED": "Special",
     }
     return mapped_status[media_status]
 
 
 def getSynonyms(request):
     synonyms = []
-    synonyms.extend(request.get('synonyms'))
+    synonyms.extend(request.get("synonyms"))
     return synonyms
 
 
 def getTitles(request):
     titles = []
-    titles.append(request.get('title_english'))
-    titles.append(request.get('title_romaji'))
+    titles.append(request.get("title_english"))
+    titles.append(request.get("title_romaji"))
     return titles
 
 
 def detailsBySearch(searchText, mediaType):
     try:
-        search_variables = {
-            'search': searchText,
-            'type': mediaType
-        }
+        search_variables = {"search": searchText, "type": mediaType}
 
-        payload = {'query': search_query, 'variables': search_variables}
+        payload = {"query": search_query, "variables": search_variables}
         request = req.post(uri, json=payload)
         req.close()
 
@@ -201,11 +202,9 @@ def detailsBySearch(searchText, mediaType):
 
 def detailsById(idToFind):
     try:
-        id_variables = {
-            'id': int(idToFind)
-        }
+        id_variables = {"id": int(idToFind)}
 
-        payload = {'query': id_query, 'variables': id_variables}
+        payload = {"query": id_query, "variables": id_variables}
         request = req.post(uri, json=payload)
         req.close()
 
@@ -223,7 +222,7 @@ def getAnimeDetails(searchText):
     given searchtext
     """
     try:
-        results = detailsBySearch(searchText, 'ANIME')
+        results = detailsBySearch(searchText, "ANIME")
 
         # Of the given list of shows, we try to find the one we think is
         # closest to our search term
@@ -265,24 +264,21 @@ def getClosestAnime(searchText, animeList):
         # against shows with multiple adaptations and similar synonyms
         # (e.g. Haiyore Nyaruko-San)
         for anime in animeList:
-            if 'title_english' in anime and anime['title_english']:
-                animeNameList.append(anime['title_english'].lower())
-                animeNameListNoSyn.append(anime['title_english'].lower())
+            if "title_english" in anime and anime["title_english"]:
+                animeNameList.append(anime["title_english"].lower())
+                animeNameListNoSyn.append(anime["title_english"].lower())
 
-            if 'title_romaji' in anime and anime['title_romaji']:
-                animeNameList.append(anime['title_romaji'].lower())
-                animeNameListNoSyn.append(anime['title_romaji'].lower())
+            if "title_romaji" in anime and anime["title_romaji"]:
+                animeNameList.append(anime["title_romaji"].lower())
+                animeNameListNoSyn.append(anime["title_romaji"].lower())
 
-            if 'synonyms' in anime and anime['synonyms']:
-                for synonym in anime['synonyms']:
+            if "synonyms" in anime and anime["synonyms"]:
+                for synonym in anime["synonyms"]:
                     animeNameList.append(synonym.lower())
 
         try:
             matches = difflib.get_close_matches(
-                word=searchText.lower(),
-                possibilities=animeNameList,
-                n=1,
-                cutoff=0.95,
+                word=searchText.lower(), possibilities=animeNameList, n=1, cutoff=0.95
             )
             closestNameFromList = matches[0]
         except Exception:
@@ -291,17 +287,18 @@ def getClosestAnime(searchText, animeList):
         if closestNameFromList:
             closestNameFromList = closestNameFromList.lower()
             for anime in animeList:
-                title_english = (anime.get('title_english') or '').lower()
-                title_romaji = (anime.get('title_romaji') or '').lower()
+                title_english = (anime.get("title_english") or "").lower()
+                title_romaji = (anime.get("title_romaji") or "").lower()
                 if title_english == closestNameFromList:
                     return anime
                 elif title_romaji == closestNameFromList:
                     return anime
                 else:
-                    for synonym in anime['synonyms']:
+                    for synonym in anime["synonyms"]:
                         synonym = synonym.lower()
                         if (synonym == closestNameFromList) and (
-                                synonym not in animeNameListNoSyn):
+                            synonym not in animeNameListNoSyn
+                        ):
                             return anime
 
         return None
@@ -319,7 +316,7 @@ def getMangaDetails(searchText, isLN=False):
     Returns the closest manga series given a specific search term
     """
     try:
-        results = detailsBySearch(searchText, 'MANGA')
+        results = detailsBySearch(searchText, "MANGA")
 
         closestManga = getClosestManga(searchText, results, isLN)
 
@@ -350,28 +347,25 @@ def getClosestManga(searchText, mangaList, isLN=False):
         mangaNameList = []
 
         for manga in mangaList:
-            if isLN and 'novel' not in manga['type'].lower():
+            if isLN and "novel" not in manga["type"].lower():
                 mangaList.remove(manga)
-            elif not isLN and 'novel' in manga['type'].lower():
+            elif not isLN and "novel" in manga["type"].lower():
                 mangaList.remove(manga)
 
         for manga in mangaList:
-            title_english = manga.get('title_english')
-            title_romaji = manga.get('title_romaji')
+            title_english = manga.get("title_english")
+            title_romaji = manga.get("title_romaji")
             if title_english:
                 mangaNameList.append(title_english.lower())
             if title_romaji:
                 mangaNameList.append(title_romaji.lower())
 
-            for synonym in manga['synonyms']:
+            for synonym in manga["synonyms"]:
                 mangaNameList.append(synonym.lower())
 
         try:
             matches = difflib.get_close_matches(
-                word=searchText.lower(),
-                possibilities=mangaNameList,
-                n=1,
-                cutoff=0.90,
+                word=searchText.lower(), possibilities=mangaNameList, n=1, cutoff=0.90
             )
             closestNameFromList = matches[0]
         except Exception:
@@ -380,16 +374,16 @@ def getClosestManga(searchText, mangaList, isLN=False):
         if closestNameFromList:
             closestNameFromList = closestNameFromList.lower()
             for manga in mangaList:
-                if not ('one shot' in manga['type'].lower()):
-                    title_english = (manga.get('title_english') or '').lower()
-                    title_romaji = (manga.get('title_romaji') or '').lower()
+                if not ("one shot" in manga["type"].lower()):
+                    title_english = (manga.get("title_english") or "").lower()
+                    title_romaji = (manga.get("title_romaji") or "").lower()
                     if title_english == closestNameFromList:
                         return manga
                     if title_romaji == closestNameFromList:
                         return manga
 
             for manga in mangaList:
-                for synonym in manga['synonyms']:
+                for synonym in manga["synonyms"]:
                     if synonym.lower() == closestNameFromList:
                         return manga
 

--- a/roboragi/AnimePlanet.py
+++ b/roboragi/AnimePlanet.py
@@ -34,14 +34,14 @@ req = requests.Session()
 
 
 def sanitiseSearchText(searchText):
-    return searchText.replace('(TV)', 'TV')
+    return searchText.replace("(TV)", "TV")
 
 
 def getAnimeURL(searchText):
     try:
         searchText = sanitiseSearchText(searchText)
 
-        url = urljoin(BASE_URL, '/anime/all?name=' + quote(searchText))
+        url = urljoin(BASE_URL, "/anime/all?name=" + quote(searchText))
         html = req.get(url, timeout=10)
         req.close()
         ap = pq(html.text)
@@ -49,21 +49,20 @@ def getAnimeURL(searchText):
         animeList = []
 
         # If it's taken us to the search page
-        if 'https://www.anime-planet.com/anime/all?' in html.url.lower():
-            for entry in ap.find('.cardDeck li'):
-                entryDetails = pq(pq(entry).find('a').attr('title'))
+        if "https://www.anime-planet.com/anime/all?" in html.url.lower():
+            for entry in ap.find(".cardDeck li"):
+                entryDetails = pq(pq(entry).find("a").attr("title"))
 
-                entryTitle = pq(entryDetails).find('h5').text()
-                altTitle = pq(entryDetails) \
-                    .find('.aka') \
-                    .text() \
-                    .replace('Alt title: ', '')
-                entryURL = pq(entry).find('a').attr('href')
+                entryTitle = pq(entryDetails).find("h5").text()
+                altTitle = (
+                    pq(entryDetails).find(".aka").text().replace("Alt title: ", "")
+                )
+                entryURL = pq(entry).find("a").attr("href")
 
                 anime = {}
-                anime['title'] = entryTitle
-                anime['alt_title'] = altTitle
-                anime['url'] = BASE_URL + entryURL
+                anime["title"] = entryTitle
+                anime["alt_title"] = altTitle
+                anime["url"] = BASE_URL + entryURL
                 animeList.append(anime)
 
             searchText = searchText.lower()
@@ -71,30 +70,30 @@ def getAnimeURL(searchText):
             try:
                 matches = difflib.get_close_matches(
                     word=searchText,
-                    possibilities=[a['title'].lower() for a in animeList],
+                    possibilities=[a["title"].lower() for a in animeList],
                     n=1,
-                    cutoff=0.85
+                    cutoff=0.85,
                 )
             except Exception:
                 matches = difflib.get_close_matches(
                     word=searchText,
-                    possibilities=[a['alt_title'].lower() for a in animeList],
+                    possibilities=[a["alt_title"].lower() for a in animeList],
                     n=1,
-                    cutoff=0.85
+                    cutoff=0.85,
                 )
 
             closestName = matches[0]
 
             for anime in animeList:
-                if anime['title'].lower() == closestName:
-                    return anime['url']
-                elif anime['alt_title'].lower() == closestName:
-                    return anime['url']
+                if anime["title"].lower() == closestName:
+                    return anime["url"]
+                elif anime["alt_title"].lower() == closestName:
+                    return anime["url"]
 
         # Else if it's taken us right to the series page, get the url from the
         # meta tag
         else:
-            return ap.find("meta[property='og:url']").attr('content')
+            return ap.find("meta[property='og:url']").attr("content")
         return None
 
     except Exception:
@@ -109,7 +108,7 @@ def getMangaURL(searchText, authorName=None):
     anime/manga down the line
     """
     try:
-        url = urljoin(BASE_URL, '/manga/all?name=' + quote(searchText))
+        url = urljoin(BASE_URL, "/manga/all?name=" + quote(searchText))
         html = req.get(url, timeout=10)
         req.close()
 
@@ -118,21 +117,20 @@ def getMangaURL(searchText, authorName=None):
         mangaList = []
 
         # If it's taken us to the search page
-        if 'https://www.anime-planet.com/manga/all?' in html.url.lower():
-            for entry in ap.find('.card'):
-                entryDetails = pq(pq(entry).find('a').attr('title'))
+        if "https://www.anime-planet.com/manga/all?" in html.url.lower():
+            for entry in ap.find(".card"):
+                entryDetails = pq(pq(entry).find("a").attr("title"))
 
-                entryTitle = pq(entryDetails).find('h5').text()
-                altTitle = pq(entryDetails) \
-                    .find('.aka') \
-                    .text() \
-                    .replace('Alt title: ', '')
-                entryURL = pq(entry).find('a').attr('href')
+                entryTitle = pq(entryDetails).find("h5").text()
+                altTitle = (
+                    pq(entryDetails).find(".aka").text().replace("Alt title: ", "")
+                )
+                entryURL = pq(entry).find("a").attr("href")
 
                 manga = {}
-                manga['title'] = entryTitle
-                manga['alt_title'] = altTitle
-                manga['url'] = BASE_URL + entryURL
+                manga["title"] = entryTitle
+                manga["alt_title"] = altTitle
+                manga["url"] = BASE_URL + entryURL
                 mangaList.append(manga)
 
             searchText = searchText.lower()
@@ -140,30 +138,30 @@ def getMangaURL(searchText, authorName=None):
             try:
                 matches = difflib.get_close_matches(
                     word=searchText,
-                    possibilities=[x['title'].lower() for x in mangaList],
+                    possibilities=[x["title"].lower() for x in mangaList],
                     n=1,
-                    cutoff=0.85
+                    cutoff=0.85,
                 )
             except Exception:
                 matches = difflib.get_close_matches(
                     word=searchText,
-                    possibilities=[x['alt_title'].lower() for x in mangaList],
+                    possibilities=[x["alt_title"].lower() for x in mangaList],
                     n=1,
-                    cutoff=0.85
+                    cutoff=0.85,
                 )
 
             closestName = matches[0]
 
             for manga in mangaList:
-                if manga['title'].lower() == closestName:
-                    return manga['url']
-                elif manga['alt_title'].lower() == closestName:
-                    return manga['url']
+                if manga["title"].lower() == closestName:
+                    return manga["url"]
+                elif manga["alt_title"].lower() == closestName:
+                    return manga["url"]
 
         # Else if it's taken us right to the series page, get the url from the
         # meta tag
         else:
-            return ap.find("meta[property='og:url']").attr('content')
+            return ap.find("meta[property='og:url']").attr("content")
         return None
 
     except Exception:
@@ -172,8 +170,8 @@ def getMangaURL(searchText, authorName=None):
 
 
 def getAnimeURLById(animeId):
-    return 'https://www.anime-planet.com/anime/' + str(animeId)
+    return "https://www.anime-planet.com/anime/" + str(animeId)
 
 
 def getMangaURLById(mangaId):
-    return 'https://www.anime-planet.com/manga/' + str(mangaId)
+    return "https://www.anime-planet.com/manga/" + str(mangaId)

--- a/roboragi/CommentBuilder.py
+++ b/roboragi/CommentBuilder.py
@@ -1,7 +1,7 @@
-'''
+"""
 CommentBuilder.py
 Takes the data given to it by search and formats it into a comment
-'''
+"""
 
 # Copyright (C) 2018  Nihilate
 #
@@ -29,35 +29,37 @@ import DatabaseHandler
 # Removes the (Source: MAL) or (Written by X) bits from the decriptions in the databases
 def cleanupDescription(desc):
     for match in re.finditer("([\[\<\(](.*?)[\]\>\)])", desc, re.S):
-        if 'ource' in match.group(1).lower():
-            desc = desc.replace(match.group(1), '')
-        if 'MAL' in match.group(1):
-            desc = desc.replace(match.group(1), '')
-        if '[From' in match.group(1):
-            desc = desc.replace(match.group(1), '')
-        if 'taken from' in match.group(1):
-            desc = desc.replace(match.group(1), '')
+        if "ource" in match.group(1).lower():
+            desc = desc.replace(match.group(1), "")
+        if "MAL" in match.group(1):
+            desc = desc.replace(match.group(1), "")
+        if "[From" in match.group(1):
+            desc = desc.replace(match.group(1), "")
+        if "taken from" in match.group(1):
+            desc = desc.replace(match.group(1), "")
 
     for match in re.finditer("([\<](.*?)[\>])", desc, re.S):
-        if 'br' in match.group(1).lower():
-            desc = desc.replace(match.group(1), '')
-        if 'i' == match.group(1).lower():
-            desc = desc.replace(match.group(1), '')
-        if 'b' == match.group(1).lower():
-            desc = desc.replace(match.group(1), '')
+        if "br" in match.group(1).lower():
+            desc = desc.replace(match.group(1), "")
+        if "i" == match.group(1).lower():
+            desc = desc.replace(match.group(1), "")
+        if "b" == match.group(1).lower():
+            desc = desc.replace(match.group(1), "")
 
-    reply = ''
-    for i, line in enumerate(linesep.join([s for s in desc.splitlines() if s]).splitlines()):
+    reply = ""
+    for i, line in enumerate(
+        linesep.join([s for s in desc.splitlines() if s]).splitlines()
+    ):
         if i is not 0:
-            reply += '\n'
-        reply += '>' + line + '\n'
+            reply += "\n"
+        reply += ">" + line + "\n"
     return reply
 
 
 # Builds an anime comment from the various data sources
 def buildAnimeComment(isExpanded, ani, ap, kit):
     try:
-        comment = ''
+        comment = ""
 
         title = None
         jTitle = None
@@ -80,171 +82,197 @@ def buildAnimeComment(isExpanded, ani, ap, kit):
         release_year = None
 
         if ani:
-            aniURL = 'http://anilist.co/anime/' + str(ani['id'])
-            malURL = 'http://myanimelist.net/anime/' + str(ani['id_mal']) if ani['id_mal'] else None
+            aniURL = "http://anilist.co/anime/" + str(ani["id"])
+            malURL = (
+                "http://myanimelist.net/anime/" + str(ani["id_mal"])
+                if ani["id_mal"]
+                else None
+            )
 
-            title = ani['title_romaji'] if 'title_romaji' in ani else ani['title_english']
-            desc = ani['description'] if 'description' in ani else None
-            status = ani['airing_status'].title() if 'airing_status' in ani else None
-            cType = ani['type'] if 'type' in ani else None
+            title = (
+                ani["title_romaji"] if "title_romaji" in ani else ani["title_english"]
+            )
+            desc = ani["description"] if "description" in ani else None
+            status = ani["airing_status"].title() if "airing_status" in ani else None
+            cType = ani["type"] if "type" in ani else None
 
-            jTitle = ani['title_japanese'] if 'title_japanese' in ani else None
-            genres = ani['genres'] if 'genres' in ani else None
+            jTitle = ani["title_japanese"] if "title_japanese" in ani else None
+            genres = ani["genres"] if "genres" in ani else None
 
             try:
-                year_str = str(ani['start_date_fuzzy']) if 'start_date_fuzzy' in ani else None
+                year_str = (
+                    str(ani["start_date_fuzzy"]) if "start_date_fuzzy" in ani else None
+                )
                 if year_str:
                     release_year = year_str[:4]
             except:
                 pass
 
-            episodes = ani['total_episodes'] if 'total_episodes' in ani else None
+            episodes = ani["total_episodes"] if "total_episodes" in ani else None
             if episodes == 0:
                 episodes = None
 
-            if ani['airing']:
-                countdown = ani['airing']['countdown']
-                nextEpisode = ani['airing']['next_episode']
+            if ani["airing"]:
+                countdown = ani["airing"]["countdown"]
+                nextEpisode = ani["airing"]["next_episode"]
 
         if kit:
-            kitURL = kit['url']
+            kitURL = kit["url"]
 
             if not title:
-                title = kit['title_romaji'] if kit['title_romaji'] else kit['title_english']
+                title = (
+                    kit["title_romaji"] if kit["title_romaji"] else kit["title_english"]
+                )
             if not desc:
-                desc = kit['description'] if 'description' in kit else None
+                desc = kit["description"] if "description" in kit else None
             if not cType:
-                cType = kit['type'].title() if 'type' in kit else None
+                cType = kit["type"].title() if "type" in kit else None
 
             try:
-                year_str = str(kit['startDate']) if 'startDate' in kit else None
+                year_str = str(kit["startDate"]) if "startDate" in kit else None
                 if year_str:
                     release_year = year_str[:4]
             except:
                 pass
 
             if not episodes:
-                episodes = kit['episode_count'] if 'episode_count' in kit else None
+                episodes = kit["episode_count"] if "episode_count" in kit else None
                 if episodes == 0:
                     episodes = None
 
-        stats = DatabaseHandler.getRequestStats(title, 'Anime')
+        stats = DatabaseHandler.getRequestStats(title, "Anime")
 
         # ---------- BUILDING THE COMMENT ----------#
 
         # ----- TITLE -----#
-        comment += '**' + title.strip() + '** - ('
+        comment += "**" + title.strip() + "** - ("
 
         # ----- LINKS -----#
         urlComments = []
 
         if ani is not None:
-            urlComments.append('[AL](' + sanitise_url_for_markdown(aniURL) + ')')
+            urlComments.append("[AL](" + sanitise_url_for_markdown(aniURL) + ")")
         if apURL is not None:
-            urlComments.append('[A-P](' + sanitise_url_for_markdown(apURL) + ')')
+            urlComments.append("[A-P](" + sanitise_url_for_markdown(apURL) + ")")
         if kit is not None:
-            urlComments.append('[KIT](' + sanitise_url_for_markdown(kitURL) + ')')
+            urlComments.append("[KIT](" + sanitise_url_for_markdown(kitURL) + ")")
         if malURL:
-            urlComments.append('[MAL](' + sanitise_url_for_markdown(malURL) + ')')
+            urlComments.append("[MAL](" + sanitise_url_for_markdown(malURL) + ")")
 
         for i, link in enumerate(urlComments):
             if i is not 0:
-                comment += ', '
+                comment += ", "
             comment += link
 
-        comment += ')'
+        comment += ")"
 
         # ----- JAPANESE TITLE -----#
-        if (isExpanded):
+        if isExpanded:
             if jTitle is not None:
-                comment += '\n\n'
+                comment += "\n\n"
 
                 splitJTitle = jTitle.split()
                 for i, word in enumerate(splitJTitle):
                     if not (i == 0):
-                        comment += ' '
-                    comment += '^^' + word
+                        comment += " "
+                    comment += "^^" + word
 
         # ----- INFO LINE -----#
-        if (isExpanded):
-            comment += '\n\n^('
+        if isExpanded:
+            comment += "\n\n^("
 
             if cType:
-                comment += '**' + cType + '** | '
+                comment += "**" + cType + "** | "
 
             if release_year:
-                comment += '**' + release_year + '**'
+                comment += "**" + release_year + "**"
 
             if status:
-                comment += ' | **Status:** ' + status
+                comment += " | **Status:** " + status
 
-            if cType != 'Movie' and episodes:
-                comment += ' | **Episodes:** ' + str(episodes)
+            if cType != "Movie" and episodes:
+                comment += " | **Episodes:** " + str(episodes)
         else:
-            comment += '\n\n^('
+            comment += "\n\n^("
 
             if cType:
                 comment += cType
 
             if status:
-                comment += ' | Status: ' + status
+                comment += " | Status: " + status
 
-            if cType != 'Movie' and episodes:
-                comment += ' | Episodes: ' + str(episodes)
+            if cType != "Movie" and episodes:
+                comment += " | Episodes: " + str(episodes)
 
         if genres:
-            if (isExpanded):
-                comment += ' | **Genres:** '
+            if isExpanded:
+                comment += " | **Genres:** "
             else:
-                comment += ' | Genres: '
+                comment += " | Genres: "
 
             for i, genre in enumerate(genres):
                 if i is not 0:
-                    comment += ', '
+                    comment += ", "
                 comment += genre
 
-        comment += ')'
+        comment += ")"
 
         if (isExpanded) and (stats is not None):
-            comment += '  \n^(**Stats:** ' + str(stats['total']) + ' requests across ' + str(
-                stats['uniqueSubreddits']) + ' subreddits - ' + str(
-                round(stats['totalAsPercentage'], 3)) + '% of all requests)'
+            comment += (
+                "  \n^(**Stats:** "
+                + str(stats["total"])
+                + " requests across "
+                + str(stats["uniqueSubreddits"])
+                + " subreddits - "
+                + str(round(stats["totalAsPercentage"], 3))
+                + "% of all requests)"
+            )
 
         # ----- EPISODE COUNTDOWN -----#
         if (countdown is not None) and (nextEpisode is not None):
             current_utc_time = datetime.datetime.utcnow()
             air_time_in_utc = current_utc_time + datetime.timedelta(0, countdown)
-            formatted_time = air_time_in_utc.strftime('%Y%m%dT%H%M')
+            formatted_time = air_time_in_utc.strftime("%Y%m%dT%H%M")
 
             # countdown is given to us in seconds
             days, countdown = divmod(countdown, 24 * 60 * 60)
             hours, countdown = divmod(countdown, 60 * 60)
             minutes, countdown = divmod(countdown, 60)
 
-            comment += '\n\n^[Episode&#32;' + str(nextEpisode) + '&#32;airs&#32;in&#32;' + str(
-                days) + '&#32;days,&#32;' + str(hours) + '&#32;hours,&#32;' + str(
-                minutes) + '&#32;minutes](https://www.timeanddate.com/worldclock/fixedtime.html?iso=' + formatted_time + ')'
+            comment += (
+                "\n\n^[Episode&#32;"
+                + str(nextEpisode)
+                + "&#32;airs&#32;in&#32;"
+                + str(days)
+                + "&#32;days,&#32;"
+                + str(hours)
+                + "&#32;hours,&#32;"
+                + str(minutes)
+                + "&#32;minutes](https://www.timeanddate.com/worldclock/fixedtime.html?iso="
+                + formatted_time
+                + ")"
+            )
 
         # ----- DESCRIPTION -----#
-        if (isExpanded):
-            comment += '\n\n' + cleanupDescription(desc)
+        if isExpanded:
+            comment += "\n\n" + cleanupDescription(desc)
 
         # ----- END -----#
-        receipt = '(A) Request successful: ' + title + ' - '
+        receipt = "(A) Request successful: " + title + " - "
         if malURL is not None:
-            receipt += 'MAL '
+            receipt += "MAL "
         if apURL is not None:
-            receipt += 'AP '
+            receipt += "AP "
         if ani is not None:
-            receipt += 'AL '
+            receipt += "AL "
         if kit is not None:
-            receipt += 'KIT '
+            receipt += "KIT "
         print(receipt)
 
         # We return the title/comment separately so we can track if multiples of the same comment have been requests (e.g. {Nisekoi}{Nisekoi}{Nisekoi})
         dictToReturn = {}
-        dictToReturn['title'] = title
-        dictToReturn['comment'] = comment
+        dictToReturn["title"] = title
+        dictToReturn["comment"] = comment
 
         return dictToReturn
     except:
@@ -255,7 +283,7 @@ def buildAnimeComment(isExpanded, ani, ap, kit):
 # Builds a manga comment from MAL/Anilist/MangaUpdates data
 def buildMangaComment(isExpanded, ani, mu, ap, kit):
     try:
-        comment = ''
+        comment = ""
 
         title = None
         jTitle = None
@@ -276,164 +304,180 @@ def buildMangaComment(isExpanded, ani, mu, ap, kit):
         desc = None
 
         if ani:
-            aniURL = 'http://anilist.co/manga/' + str(ani['id'])
-            malURL = 'http://myanimelist.net/manga/' + str(ani['id_mal']) if ani['id_mal'] else None
+            aniURL = "http://anilist.co/manga/" + str(ani["id"])
+            malURL = (
+                "http://myanimelist.net/manga/" + str(ani["id_mal"])
+                if ani["id_mal"]
+                else None
+            )
 
-            title = ani['title_romaji'] if 'title_romaji' in ani else ani['title_english']
-            desc = ani['description'] if 'description' in ani else None
-            status = ani['publishing_status'].title() if 'publishing_status' in ani else None
-            cType = ani['type'] if 'type' in ani else None
+            title = (
+                ani["title_romaji"] if "title_romaji" in ani else ani["title_english"]
+            )
+            desc = ani["description"] if "description" in ani else None
+            status = (
+                ani["publishing_status"].title() if "publishing_status" in ani else None
+            )
+            cType = ani["type"] if "type" in ani else None
 
-            jTitle = ani['title_japanese'] if 'title_japanese' in ani else None
-            genres = ani['genres'] if 'genres' in ani else None
+            jTitle = ani["title_japanese"] if "title_japanese" in ani else None
+            genres = ani["genres"] if "genres" in ani else None
 
-            chapters = ani['total_chapters'] if 'total_chapters' in ani else None
+            chapters = ani["total_chapters"] if "total_chapters" in ani else None
             if chapters == 0:
                 chapters = None
-            volumes = ani['total_volumes'] if 'total_volumes' in ani else None
+            volumes = ani["total_volumes"] if "total_volumes" in ani else None
             if volumes == 0:
                 volumes = None
 
         if kit:
-            kitURL = kit['url']
+            kitURL = kit["url"]
 
             if not title:
-                title = kit['title_romaji'] if kit['title_romaji'] else kit['title_english']
+                title = (
+                    kit["title_romaji"] if kit["title_romaji"] else kit["title_english"]
+                )
             if not desc:
-                desc = kit['description'] if 'description' in kit else None
+                desc = kit["description"] if "description" in kit else None
             if not cType:
-                cType = kit['type'].title() if 'type' in kit else None
+                cType = kit["type"].title() if "type" in kit else None
 
             if not chapters:
-                chapters = kit['chapter_count'] if 'chapter_count' in kit else None
+                chapters = kit["chapter_count"] if "chapter_count" in kit else None
                 if chapters == 0:
                     chapters = None
             if not volumes:
-                volumes = kit['volume_count'] if 'volume_count' in kit else None
+                volumes = kit["volume_count"] if "volume_count" in kit else None
                 if volumes == 0:
                     volumes = None
 
-        stats = DatabaseHandler.getRequestStats(title, 'Manga')
+        stats = DatabaseHandler.getRequestStats(title, "Manga")
 
         # ---------- BUILDING THE COMMENT ----------#
 
         # ----- TITLE -----#
-        comment += '**' + title.strip() + '** - ('
+        comment += "**" + title.strip() + "** - ("
 
         # ----- LINKS -----#
         urlComments = []
 
         if aniURL is not None:
-            urlComments.append('[AL](' + sanitise_url_for_markdown(aniURL) + ')')
+            urlComments.append("[AL](" + sanitise_url_for_markdown(aniURL) + ")")
         if apURL is not None:
-            urlComments.append('[A-P](' + sanitise_url_for_markdown(apURL) + ')')
+            urlComments.append("[A-P](" + sanitise_url_for_markdown(apURL) + ")")
         if kitURL is not None:
-            urlComments.append('[KIT](' + sanitise_url_for_markdown(kitURL) + ')')
+            urlComments.append("[KIT](" + sanitise_url_for_markdown(kitURL) + ")")
         if muURL is not None:
-            urlComments.append('[MU](' + sanitise_url_for_markdown(muURL) + ')')
+            urlComments.append("[MU](" + sanitise_url_for_markdown(muURL) + ")")
         if malURL:
-            urlComments.append('[MAL](' + sanitise_url_for_markdown(malURL) + ')')
+            urlComments.append("[MAL](" + sanitise_url_for_markdown(malURL) + ")")
 
         for i, link in enumerate(urlComments):
             if i is not 0:
-                comment += ', '
+                comment += ", "
             comment += link
 
-        comment += ')'
+        comment += ")"
 
         # ----- JAPANESE TITLE -----#
-        if (isExpanded):
+        if isExpanded:
             if jTitle is not None:
-                comment += '\n\n'
+                comment += "\n\n"
 
                 splitJTitle = jTitle.split()
                 for i, word in enumerate(splitJTitle):
                     if not (i == 0):
-                        comment += ' '
-                    comment += '^^' + word
+                        comment += " "
+                    comment += "^^" + word
 
         # ----- INFO LINE -----#
 
-        if (isExpanded):
-            comment += '\n\n^('
+        if isExpanded:
+            comment += "\n\n^("
 
             if cType:
-                if cType == 'Novel':
-                    cType = 'Light Novel'
+                if cType == "Novel":
+                    cType = "Light Novel"
 
-                comment += '**' + cType + '**'
+                comment += "**" + cType + "**"
 
             if status:
-                comment += ' | **Status:** ' + status
+                comment += " | **Status:** " + status
 
-            if (cType != 'Light Novel'):
-                if volumes and str(volumes) is not 'Unknown':
-                    comment += ' | **Volumes:** ' + str(volumes)
-                if chapters and str(chapters) is not 'Unknown':
-                    comment += ' | **Chapters:** ' + str(chapters)
+            if cType != "Light Novel":
+                if volumes and str(volumes) is not "Unknown":
+                    comment += " | **Volumes:** " + str(volumes)
+                if chapters and str(chapters) is not "Unknown":
+                    comment += " | **Chapters:** " + str(chapters)
             else:
-                if volumes and str(volumes) is not 'Unknown':
-                    comment += ' | **Volumes:** ' + str(volumes)
+                if volumes and str(volumes) is not "Unknown":
+                    comment += " | **Volumes:** " + str(volumes)
         else:
-            comment += '\n\n^('
+            comment += "\n\n^("
 
             if cType:
-                if cType == 'Novel':
-                    cType = 'Light Novel'
+                if cType == "Novel":
+                    cType = "Light Novel"
 
                 comment += cType
 
             if status:
-                comment += ' | Status: ' + status
+                comment += " | Status: " + status
 
-            if (cType != 'Light Novel'):
-                if volumes and str(volumes) is not 'Unknown':
-                    comment += ' | Volumes: ' + str(volumes)
-                if chapters and str(chapters) is not 'Unknown':
-                    comment += ' | Chapters: ' + str(chapters)
+            if cType != "Light Novel":
+                if volumes and str(volumes) is not "Unknown":
+                    comment += " | Volumes: " + str(volumes)
+                if chapters and str(chapters) is not "Unknown":
+                    comment += " | Chapters: " + str(chapters)
             else:
-                if volumes and str(volumes) is not 'Unknown':
-                    comment += ' | Volumes: ' + str(volumes)
+                if volumes and str(volumes) is not "Unknown":
+                    comment += " | Volumes: " + str(volumes)
 
         if genres:
-            if (isExpanded):
-                comment += ' | **Genres:** '
+            if isExpanded:
+                comment += " | **Genres:** "
             else:
-                comment += ' | Genres: '
+                comment += " | Genres: "
 
             for i, genre in enumerate(genres):
                 if i is not 0:
-                    comment += ', '
+                    comment += ", "
                 comment += genre
 
-        comment += ')'
+        comment += ")"
 
         if (isExpanded) and (stats is not None):
-            comment += '  \n^(**Stats:** ' + str(stats['total']) + ' requests across ' + str(
-                stats['uniqueSubreddits']) + ' subreddits - ' + str(
-                round(stats['totalAsPercentage'], 3)) + '% of all requests)'
+            comment += (
+                "  \n^(**Stats:** "
+                + str(stats["total"])
+                + " requests across "
+                + str(stats["uniqueSubreddits"])
+                + " subreddits - "
+                + str(round(stats["totalAsPercentage"], 3))
+                + "% of all requests)"
+            )
 
         # ----- DESCRIPTION -----#
-        if (isExpanded):
-            comment += '\n\n' + cleanupDescription(desc)
+        if isExpanded:
+            comment += "\n\n" + cleanupDescription(desc)
 
         # ----- END -----#
-        receipt = '(M) Request successful: ' + title + ' - '
+        receipt = "(M) Request successful: " + title + " - "
         if malURL is not None:
-            receipt += 'MAL '
+            receipt += "MAL "
         if ap is not None:
-            receipt += 'AP '
+            receipt += "AP "
         if ani is not None:
-            receipt += 'AL '
+            receipt += "AL "
         if kit is not None:
-            receipt += 'KIT '
+            receipt += "KIT "
         if muURL is not None:
-            receipt += 'MU '
+            receipt += "MU "
         print(receipt)
 
         dictToReturn = {}
-        dictToReturn['title'] = title
-        dictToReturn['comment'] = comment
+        dictToReturn["title"] = title
+        dictToReturn["comment"] = comment
 
         return dictToReturn
     except:
@@ -444,7 +488,7 @@ def buildMangaComment(isExpanded, ani, mu, ap, kit):
 # Builds a manga comment from MAL/Anilist/MangaUpdates data
 def buildLightNovelComment(isExpanded, ani, nu, lndb, kit):
     try:
-        comment = ''
+        comment = ""
 
         title = None
         jTitle = None
@@ -465,165 +509,182 @@ def buildLightNovelComment(isExpanded, ani, nu, lndb, kit):
         desc = None
 
         if ani:
-            aniURL = 'http://anilist.co/manga/' + str(ani['id'])
-            malURL = 'http://myanimelist.net/manga/' + str(ani['id_mal']) if ani['id_mal'] else None
+            aniURL = "http://anilist.co/manga/" + str(ani["id"])
+            malURL = (
+                "http://myanimelist.net/manga/" + str(ani["id_mal"])
+                if ani["id_mal"]
+                else None
+            )
 
-            title = ani['title_romaji'] if 'title_romaji' in ani else ani['title_english']
-            desc = ani['description'] if 'description' in ani else None
-            status = ani['publishing_status'].title() if 'publishing_status' in ani and ani[
-                'publishing_status'] else None
-            cType = ani['type'] if 'type' in ani else None
+            title = (
+                ani["title_romaji"] if "title_romaji" in ani else ani["title_english"]
+            )
+            desc = ani["description"] if "description" in ani else None
+            status = (
+                ani["publishing_status"].title()
+                if "publishing_status" in ani and ani["publishing_status"]
+                else None
+            )
+            cType = ani["type"] if "type" in ani else None
 
-            jTitle = ani['title_japanese'] if 'title_japanese' in ani else None
-            genres = ani['genres'] if 'genres' in ani else None
+            jTitle = ani["title_japanese"] if "title_japanese" in ani else None
+            genres = ani["genres"] if "genres" in ani else None
 
-            chapters = ani['total_chapters'] if 'total_chapters' in ani else None
+            chapters = ani["total_chapters"] if "total_chapters" in ani else None
             if chapters == 0:
                 chapters = None
-            volumes = ani['total_volumes'] if 'total_volumes' in ani else None
+            volumes = ani["total_volumes"] if "total_volumes" in ani else None
             if volumes == 0:
                 volumes = None
 
         if kit:
-            kitURL = kit['url']
+            kitURL = kit["url"]
 
             if not title:
-                title = kit['title_romaji'] if kit['title_romaji'] else kit['title_english']
+                title = (
+                    kit["title_romaji"] if kit["title_romaji"] else kit["title_english"]
+                )
             if not desc:
-                desc = kit['description'] if 'description' in kit else None
+                desc = kit["description"] if "description" in kit else None
             if not cType:
-                cType = kit['type'].title() if 'type' in kit else None
+                cType = kit["type"].title() if "type" in kit else None
 
             if not chapters:
-                chapters = kit['chapter_count'] if 'chapter_count' in kit else None
+                chapters = kit["chapter_count"] if "chapter_count" in kit else None
                 if chapters == 0:
                     chapters = None
             if not volumes:
-                volumes = kit['volume_count'] if 'volume_count' in kit else None
+                volumes = kit["volume_count"] if "volume_count" in kit else None
                 if volumes == 0:
                     volumes = None
 
-        stats = DatabaseHandler.getRequestStats(title, 'LN')
+        stats = DatabaseHandler.getRequestStats(title, "LN")
 
         # ---------- BUILDING THE COMMENT ----------#
 
         # ----- TITLE -----#
-        comment += '**' + title.strip() + '** - ('
+        comment += "**" + title.strip() + "** - ("
 
         # ----- LINKS -----#
         urlComments = []
 
         if aniURL is not None:
-            urlComments.append('[AL](' + sanitise_url_for_markdown(aniURL) + ')')
+            urlComments.append("[AL](" + sanitise_url_for_markdown(aniURL) + ")")
         if kitURL is not None:
-            urlComments.append('[KIT](' + sanitise_url_for_markdown(kitURL) + ')')
+            urlComments.append("[KIT](" + sanitise_url_for_markdown(kitURL) + ")")
         if nuURL is not None:
-            urlComments.append('[NU](' + sanitise_url_for_markdown(nuURL) + ')')
+            urlComments.append("[NU](" + sanitise_url_for_markdown(nuURL) + ")")
         if lndbURL is not None:
-            urlComments.append('[LNDB](' + sanitise_url_for_markdown(lndbURL) + ')')
+            urlComments.append("[LNDB](" + sanitise_url_for_markdown(lndbURL) + ")")
         if malURL:
-            urlComments.append('[MAL](' + sanitise_url_for_markdown(malURL) + ')')
+            urlComments.append("[MAL](" + sanitise_url_for_markdown(malURL) + ")")
 
         for i, link in enumerate(urlComments):
             if i is not 0:
-                comment += ', '
+                comment += ", "
             comment += link
 
-        comment += ')'
+        comment += ")"
 
         # ----- JAPANESE TITLE -----#
-        if (isExpanded):
+        if isExpanded:
             if jTitle is not None:
-                comment += '\n\n'
+                comment += "\n\n"
 
                 splitJTitle = jTitle.split()
                 for i, word in enumerate(splitJTitle):
                     if not (i == 0):
-                        comment += ' '
-                    comment += '^^' + word
+                        comment += " "
+                    comment += "^^" + word
 
         # ----- INFO LINE -----#
 
-        if (isExpanded):
-            comment += '\n\n^('
+        if isExpanded:
+            comment += "\n\n^("
 
             if cType:
-                if cType == 'Novel':
-                    cType = 'Light Novel'
+                if cType == "Novel":
+                    cType = "Light Novel"
 
-                comment += '**' + cType + '**'
+                comment += "**" + cType + "**"
 
             if status:
-                comment += ' | **Status:** ' + status
+                comment += " | **Status:** " + status
 
-            if (cType != 'Light Novel'):
-                if volumes and str(volumes) is not 'Unknown':
-                    comment += ' | **Volumes:** ' + str(volumes)
-                if chapters and str(chapters) is not 'Unknown':
-                    comment += ' | **Chapters:** ' + str(chapters)
+            if cType != "Light Novel":
+                if volumes and str(volumes) is not "Unknown":
+                    comment += " | **Volumes:** " + str(volumes)
+                if chapters and str(chapters) is not "Unknown":
+                    comment += " | **Chapters:** " + str(chapters)
             else:
-                if volumes and str(volumes) is not 'Unknown':
-                    comment += ' | **Volumes:** ' + str(volumes)
+                if volumes and str(volumes) is not "Unknown":
+                    comment += " | **Volumes:** " + str(volumes)
         else:
-            comment += '\n\n^('
+            comment += "\n\n^("
 
             if cType:
-                if cType == 'Novel':
-                    cType = 'Light Novel'
+                if cType == "Novel":
+                    cType = "Light Novel"
 
                 comment += cType
 
             if status:
-                comment += ' | Status: ' + status
+                comment += " | Status: " + status
 
-            if (cType != 'Light Novel'):
-                if volumes and str(volumes) is not 'Unknown':
-                    comment += ' | Volumes: ' + str(volumes)
-                if chapters and str(chapters) is not 'Unknown':
-                    comment += ' | Chapters: ' + str(chapters)
+            if cType != "Light Novel":
+                if volumes and str(volumes) is not "Unknown":
+                    comment += " | Volumes: " + str(volumes)
+                if chapters and str(chapters) is not "Unknown":
+                    comment += " | Chapters: " + str(chapters)
             else:
-                if volumes and str(volumes) is not 'Unknown':
-                    comment += ' | Volumes: ' + str(volumes)
+                if volumes and str(volumes) is not "Unknown":
+                    comment += " | Volumes: " + str(volumes)
 
         if genres:
-            if (isExpanded):
-                comment += ' | **Genres:** '
+            if isExpanded:
+                comment += " | **Genres:** "
             else:
-                comment += ' | Genres: '
+                comment += " | Genres: "
 
             for i, genre in enumerate(genres):
                 if i is not 0:
-                    comment += ', '
+                    comment += ", "
                 comment += genre
 
-        comment += ')'
+        comment += ")"
 
         if (isExpanded) and (stats is not None):
-            comment += '  \n^(**Stats:** ' + str(stats['total']) + ' requests across ' + str(
-                stats['uniqueSubreddits']) + ' subreddits - ' + str(
-                round(stats['totalAsPercentage'], 3)) + '% of all requests)'
+            comment += (
+                "  \n^(**Stats:** "
+                + str(stats["total"])
+                + " requests across "
+                + str(stats["uniqueSubreddits"])
+                + " subreddits - "
+                + str(round(stats["totalAsPercentage"], 3))
+                + "% of all requests)"
+            )
 
         # ----- DESCRIPTION -----#
-        if (isExpanded):
-            comment += '\n\n' + cleanupDescription(desc)
+        if isExpanded:
+            comment += "\n\n" + cleanupDescription(desc)
 
         # ----- END -----#
-        receipt = '(LN) Request successful: ' + title + ' - '
+        receipt = "(LN) Request successful: " + title + " - "
         if malURL is not None:
-            receipt += 'MAL '
+            receipt += "MAL "
         if ani is not None:
-            receipt += 'AL '
+            receipt += "AL "
         if kit is not None:
-            receipt += 'KIT '
+            receipt += "KIT "
         if nuURL is not None:
-            receipt += 'MU '
+            receipt += "MU "
         if lndbURL is not None:
-            receipt += 'LNDB '
+            receipt += "LNDB "
         print(receipt)
 
         dictToReturn = {}
-        dictToReturn['title'] = title
-        dictToReturn['comment'] = comment
+        dictToReturn["title"] = title
+        dictToReturn["comment"] = comment
 
         return dictToReturn
     except:
@@ -632,107 +693,198 @@ def buildLightNovelComment(isExpanded, ani, nu, lndb, kit):
 
 
 def sanitise_url_for_markdown(url):
-    return url.replace('(', '\(').replace(')', '\)')
+    return url.replace("(", "\(").replace(")", "\)")
 
 
 # Builds a stats comment
 def buildStatsComment(subreddit=None, username=None):
     try:
-        statComment = ''
-        receipt = '(S) Request successful: Stats'
+        statComment = ""
+        receipt = "(S) Request successful: Stats"
 
         if username:
             userStats = DatabaseHandler.getUserStats(username)
 
             if userStats:
-                statComment += 'Some stats on /u/' + username + ':\n\n'
-                statComment += '- **' + str(userStats['totalUserComments']) + '** total comments searched (' + str(
-                    round(userStats['totalUserCommentsAsPercentage'], 3)) + '% of all comments)\n'
-                statComment += '- **' + str(userStats['totalUserRequests']) + '** requests made (' + str(
-                    round(userStats['totalUserRequestsAsPercentage'], 3)) + '% of all requests and #' + str(
-                    userStats['overallRequestRank']) + ' overall)\n'
-                statComment += '- **' + str(userStats['uniqueRequests']) + '** unique anime/manga requested\n'
-                statComment += '- **/r/' + str(
-                    userStats['favouriteSubreddit']) + '** is their favourite subreddit with ' + str(
-                    userStats['favouriteSubredditCount']) + ' requests (' + str(
-                    round(userStats['favouriteSubredditCountAsPercentage'], 3)) + '% of the subreddit\'s requests)\n'
-                statComment += '\n'
-                statComment += 'Their most frequently requested anime/manga overall are:\n\n'
+                statComment += "Some stats on /u/" + username + ":\n\n"
+                statComment += (
+                    "- **"
+                    + str(userStats["totalUserComments"])
+                    + "** total comments searched ("
+                    + str(round(userStats["totalUserCommentsAsPercentage"], 3))
+                    + "% of all comments)\n"
+                )
+                statComment += (
+                    "- **"
+                    + str(userStats["totalUserRequests"])
+                    + "** requests made ("
+                    + str(round(userStats["totalUserRequestsAsPercentage"], 3))
+                    + "% of all requests and #"
+                    + str(userStats["overallRequestRank"])
+                    + " overall)\n"
+                )
+                statComment += (
+                    "- **"
+                    + str(userStats["uniqueRequests"])
+                    + "** unique anime/manga requested\n"
+                )
+                statComment += (
+                    "- **/r/"
+                    + str(userStats["favouriteSubreddit"])
+                    + "** is their favourite subreddit with "
+                    + str(userStats["favouriteSubredditCount"])
+                    + " requests ("
+                    + str(round(userStats["favouriteSubredditCountAsPercentage"], 3))
+                    + "% of the subreddit's requests)\n"
+                )
+                statComment += "\n"
+                statComment += (
+                    "Their most frequently requested anime/manga overall are:\n\n"
+                )
 
-                for i, request in enumerate(userStats['topRequests']):
-                    statComment += str(i + 1) + '. **' + str(request[0]) + '** (' + str(request[1]) + ' - ' + str(
-                        request[2]) + ' requests)  \n'
+                for i, request in enumerate(userStats["topRequests"]):
+                    statComment += (
+                        str(i + 1)
+                        + ". **"
+                        + str(request[0])
+                        + "** ("
+                        + str(request[1])
+                        + " - "
+                        + str(request[2])
+                        + " requests)  \n"
+                    )
             else:
-                statComment += '/u/' + str(username) + ' hasn\'t used Roboragi yet.'
+                statComment += "/u/" + str(username) + " hasn't used Roboragi yet."
 
-            receipt += ' - /u/' + username
+            receipt += " - /u/" + username
         elif subreddit:
             subreddit = str(subreddit)
             subredditStats = DatabaseHandler.getSubredditStats(subreddit.lower())
 
             if subredditStats:
-                statComment += '**/r/' + subreddit + ' Stats**\n\n'
+                statComment += "**/r/" + subreddit + " Stats**\n\n"
 
-                statComment += 'I\'ve searched through ' + str(subredditStats['totalComments'])
-                statComment += ' unique comments on /r/' + subreddit
-                statComment += ' and fulfilled a total of ' + str(subredditStats['total']) + ' requests, '
-                statComment += 'representing ' + str(
-                    round(subredditStats['totalAsPercentage'], 2)) + '% of all requests. '
-                statComment += 'A total of ' + str(
-                    subredditStats['uniqueNames']) + ' unique anime/manga have been requested here, '
-                statComment += 'with a mean value of ' + str(
-                    round(subredditStats['meanValuePerRequest'], 3)) + ' requests/show'
-                statComment += ' and a standard deviation of ' + str(
-                    round(subredditStats['standardDeviation'], 3)) + '.'
+                statComment += "I've searched through " + str(
+                    subredditStats["totalComments"]
+                )
+                statComment += " unique comments on /r/" + subreddit
+                statComment += (
+                    " and fulfilled a total of "
+                    + str(subredditStats["total"])
+                    + " requests, "
+                )
+                statComment += (
+                    "representing "
+                    + str(round(subredditStats["totalAsPercentage"], 2))
+                    + "% of all requests. "
+                )
+                statComment += (
+                    "A total of "
+                    + str(subredditStats["uniqueNames"])
+                    + " unique anime/manga have been requested here, "
+                )
+                statComment += (
+                    "with a mean value of "
+                    + str(round(subredditStats["meanValuePerRequest"], 3))
+                    + " requests/show"
+                )
+                statComment += (
+                    " and a standard deviation of "
+                    + str(round(subredditStats["standardDeviation"], 3))
+                    + "."
+                )
 
-                statComment += '\n\n'
+                statComment += "\n\n"
 
-                statComment += 'The most frequently requested anime/manga on this subreddit are:\n\n'
+                statComment += "The most frequently requested anime/manga on this subreddit are:\n\n"
 
-                for i, request in enumerate(subredditStats['topRequests']):
-                    statComment += str(i + 1) + '. **' + str(request[0]) + '** (' + str(request[1]) + ' - ' + str(
-                        request[2]) + ' requests)\n'
+                for i, request in enumerate(subredditStats["topRequests"]):
+                    statComment += (
+                        str(i + 1)
+                        + ". **"
+                        + str(request[0])
+                        + "** ("
+                        + str(request[1])
+                        + " - "
+                        + str(request[2])
+                        + " requests)\n"
+                    )
 
-                statComment += '\n'
+                statComment += "\n"
 
-                statComment += 'The most frequent requesters on this subreddit are:\n\n'
-                for i, requester in enumerate(subredditStats['topRequesters']):
-                    statComment += str(i + 1) + '. /u/' + str(requester[0]) + ' (' + str(requester[1]) + ' requests)\n'
+                statComment += "The most frequent requesters on this subreddit are:\n\n"
+                for i, requester in enumerate(subredditStats["topRequesters"]):
+                    statComment += (
+                        str(i + 1)
+                        + ". /u/"
+                        + str(requester[0])
+                        + " ("
+                        + str(requester[1])
+                        + " requests)\n"
+                    )
 
             else:
-                statComment += 'There have been no requests on /r/' + str(subreddit) + ' yet.'
+                statComment += (
+                    "There have been no requests on /r/" + str(subreddit) + " yet."
+                )
 
-            receipt += ' - /r/' + subreddit
+            receipt += " - /r/" + subreddit
         else:
             basicStats = DatabaseHandler.getBasicStats()
 
             # The overall stats section
-            statComment += '**Overall Stats**\n\n'
+            statComment += "**Overall Stats**\n\n"
 
-            statComment += 'I\'ve searched through ' + str(basicStats['totalComments'])
-            statComment += ' unique comments and fulfilled a total of ' + str(basicStats['total'])
-            statComment += ' requests across ' + str(basicStats['uniqueSubreddits']) + ' unique subreddit(s). '
-            statComment += 'A total of ' + str(basicStats['uniqueNames'])
-            statComment += ' unique anime/manga have been requested, with a mean value of ' + str(
-                round(basicStats['meanValuePerRequest'], 3))
-            statComment += ' requests/show and a standard deviation of ' + str(
-                round(basicStats['standardDeviation'], 3)) + '.'
+            statComment += "I've searched through " + str(basicStats["totalComments"])
+            statComment += " unique comments and fulfilled a total of " + str(
+                basicStats["total"]
+            )
+            statComment += (
+                " requests across "
+                + str(basicStats["uniqueSubreddits"])
+                + " unique subreddit(s). "
+            )
+            statComment += "A total of " + str(basicStats["uniqueNames"])
+            statComment += (
+                " unique anime/manga have been requested, with a mean value of "
+                + str(round(basicStats["meanValuePerRequest"], 3))
+            )
+            statComment += (
+                " requests/show and a standard deviation of "
+                + str(round(basicStats["standardDeviation"], 3))
+                + "."
+            )
 
-            statComment += '\n\n'
+            statComment += "\n\n"
 
-            statComment += 'The most frequently requested anime/manga overall are:\n\n'
+            statComment += "The most frequently requested anime/manga overall are:\n\n"
 
-            for i, request in enumerate(basicStats['topRequests']):
-                statComment += str(i + 1) + '. **' + str(request[0]) + '** (' + str(request[1]) + ' - ' + str(
-                    request[2]) + ' requests)\n'
+            for i, request in enumerate(basicStats["topRequests"]):
+                statComment += (
+                    str(i + 1)
+                    + ". **"
+                    + str(request[0])
+                    + "** ("
+                    + str(request[1])
+                    + " - "
+                    + str(request[2])
+                    + " requests)\n"
+                )
 
-            statComment += '\n'
+            statComment += "\n"
 
-            statComment += 'The most frequent requesters overall are:  \n'
-            for i, requester in enumerate(basicStats['topRequesters']):
-                statComment += str(i + 1) + '. /u/' + str(requester[0]) + ' (' + str(requester[1]) + ' requests)  \n'
+            statComment += "The most frequent requesters overall are:  \n"
+            for i, requester in enumerate(basicStats["topRequesters"]):
+                statComment += (
+                    str(i + 1)
+                    + ". /u/"
+                    + str(requester[0])
+                    + " ("
+                    + str(requester[1])
+                    + " requests)  \n"
+                )
 
-            receipt += ' - Basic'
+            receipt += " - Basic"
 
         print(receipt)
 
@@ -745,64 +897,79 @@ def buildStatsComment(subreddit=None, username=None):
 # Builds an anime comment from MAL/HB/Anilist data
 def buildVisualNovelComment(isExpanded, vndb):
     try:
-        comment = ''
+        comment = ""
 
         urls = []
-        if vndb['url']:
-            urls.append('[VNDB]({0})'.format(vndb['url']))
-        if vndb['wikipedia_url']:
-            if vndb['wikipedia_url'].endswith(')'):
-                formatted_wiki_url = vndb['wikipedia_url'][:-1] + '\)'
+        if vndb["url"]:
+            urls.append("[VNDB]({0})".format(vndb["url"]))
+        if vndb["wikipedia_url"]:
+            if vndb["wikipedia_url"].endswith(")"):
+                formatted_wiki_url = vndb["wikipedia_url"][:-1] + "\)"
             else:
-                formatted_wiki_url = vndb['wikipedia_url']
-            urls.append('[Wiki]({0})'.format(formatted_wiki_url))
+                formatted_wiki_url = vndb["wikipedia_url"]
+            urls.append("[Wiki]({0})".format(formatted_wiki_url))
 
-        formatted_links = ''
+        formatted_links = ""
         for i, link in enumerate(urls):
             if i is not 0:
-                formatted_links += ', '
+                formatted_links += ", "
             formatted_links += link
 
         if not isExpanded:
-            template = '**{title}** - {links}\n\n^({type}{released}{length})'
-            formatted = template.format(title=vndb['title'],
-                                        links='({})'.format(formatted_links),
-                                        type='VN',
-                                        released=' | Released: ' + vndb['release_year'] if vndb['release_year'] else '',
-                                        length=' | Length: ' + vndb['length'] if vndb['length'] else '')
+            template = "**{title}** - {links}\n\n^({type}{released}{length})"
+            formatted = template.format(
+                title=vndb["title"],
+                links="({})".format(formatted_links),
+                type="VN",
+                released=" | Released: " + vndb["release_year"]
+                if vndb["release_year"]
+                else "",
+                length=" | Length: " + vndb["length"] if vndb["length"] else "",
+            )
 
             comment = formatted
         else:
-            stats = DatabaseHandler.getRequestStats(vndb['title'], 'VN')
+            stats = DatabaseHandler.getRequestStats(vndb["title"], "VN")
             if stats:
-                formatted_stats = '**Stats:** ' + str(stats['total']) + ' requests across ' + str(
-                    stats['uniqueSubreddits']) + ' subreddit(s)^) ^- ^' + str(
-                    round(stats['totalAsPercentage'], 3)) + '% ^of ^all ^requests'
+                formatted_stats = (
+                    "**Stats:** "
+                    + str(stats["total"])
+                    + " requests across "
+                    + str(stats["uniqueSubreddits"])
+                    + " subreddit(s)^) ^- ^"
+                    + str(round(stats["totalAsPercentage"], 3))
+                    + "% ^of ^all ^requests"
+                )
             else:
                 formatted_stats = None
 
-            template = '**{title}** - {links}\n\n^({type}{released}{length}){stats}\n\n{desc}'
-            formatted = template.format(title=vndb['title'],
-                                        links='({})'.format(formatted_links),
-                                        type='**VN**',
-                                        released=' | **Released:** ' + vndb['release_year'] if vndb[
-                                            'release_year'] else '',
-                                        length=' | **Length:** ' + vndb['length'] if vndb['length'] else '',
-                                        stats='  \n^(' + formatted_stats if formatted_stats else '',
-                                        desc=cleanupDescription(vndb['description']))
+            template = (
+                "**{title}** - {links}\n\n^({type}{released}{length}){stats}\n\n{desc}"
+            )
+            formatted = template.format(
+                title=vndb["title"],
+                links="({})".format(formatted_links),
+                type="**VN**",
+                released=" | **Released:** " + vndb["release_year"]
+                if vndb["release_year"]
+                else "",
+                length=" | **Length:** " + vndb["length"] if vndb["length"] else "",
+                stats="  \n^(" + formatted_stats if formatted_stats else "",
+                desc=cleanupDescription(vndb["description"]),
+            )
 
             comment = formatted
 
         # ----- END -----#
-        receipt = '(VN) Request successful: ' + vndb['title'] + ' - '
+        receipt = "(VN) Request successful: " + vndb["title"] + " - "
         if vndb:
-            receipt += 'VNDB'
+            receipt += "VNDB"
         print(receipt)
 
         # We return the title/comment separately so we can track if multiples of the same comment have been requests (e.g. {Nisekoi}{Nisekoi}{Nisekoi})
         dictToReturn = {}
-        dictToReturn['title'] = vndb['title']
-        dictToReturn['comment'] = comment
+        dictToReturn["title"] = vndb["title"]
+        dictToReturn["comment"] = comment
 
         return dictToReturn
     except:

--- a/roboragi/DatabaseHandler.py
+++ b/roboragi/DatabaseHandler.py
@@ -1,8 +1,8 @@
-'''
+"""
 DatabaseHandler.py
 Handles all connections to the database. The database runs on PostgreSQL and is
 connected to via psycopg2.
-'''
+"""
 
 # Copyright (C) 2018  Nihilate
 #
@@ -24,10 +24,10 @@ from math import sqrt
 
 import psycopg2
 
-DBNAME = ''
-DBUSER = ''
-DBPASSWORD = ''
-DBHOST = ''
+DBNAME = ""
+DBUSER = ""
+DBPASSWORD = ""
+DBHOST = ""
 
 try:
     import Config
@@ -39,12 +39,7 @@ try:
 except ImportError:
     pass
 
-conn = psycopg2.connect(
-    user=DBUSER,
-    password=DBPASSWORD,
-    host=DBHOST,
-    dbname=DBNAME
-)
+conn = psycopg2.connect(user=DBUSER, password=DBPASSWORD, host=DBHOST, dbname=DBNAME)
 cur = conn.cursor()
 
 
@@ -55,10 +50,7 @@ def setup():
     """
     try:
         conn = psycopg2.connect(
-            user=DBUSER,
-            password=DBPASSWORD,
-            host=DBHOST,
-            dbname=DBNAME
+            user=DBUSER, password=DBPASSWORD, host=DBHOST, dbname=DBNAME
         )
     except Exception:
         print("Unable to connect to the database")
@@ -82,7 +74,7 @@ def setup():
         conn.commit()
     except Exception:
         # traceback.print_exc()
-        cur.execute('ROLLBACK')
+        cur.execute("ROLLBACK")
         conn.commit()
 
     create_comments_table = """
@@ -100,7 +92,7 @@ def setup():
         conn.commit()
     except Exception:
         # traceback.print_exc()
-        cur.execute('ROLLBACK')
+        cur.execute("ROLLBACK")
         conn.commit()
 
 
@@ -108,6 +100,7 @@ setup()
 
 
 # --------------------------------------#
+
 
 def _percentage(dividend, divisor):
     """ Return a percentage """
@@ -133,7 +126,7 @@ def addComment(commentid, requester, subreddit, hadRequest):
         conn.commit()
     except Exception:
         traceback.print_exc()
-        cur.execute('ROLLBACK')
+        cur.execute("ROLLBACK")
         conn.commit()
 
 
@@ -155,7 +148,7 @@ def commentExists(commentid):
             return True
     except Exception:
         traceback.print_exc()
-        cur.execute('ROLLBACK')
+        cur.execute("ROLLBACK")
         conn.commit()
         return True
 
@@ -174,12 +167,12 @@ def addRequest(name, rType, requester, subreddit):
     try:
         subreddit = str(subreddit).lower()
 
-        if ('nihilate' not in subreddit):
+        if "nihilate" not in subreddit:
             cur.execute(query, values)
             conn.commit()
     except Exception:
         # traceback.print_exc()
-        cur.execute('ROLLBACK')
+        cur.execute("ROLLBACK")
         conn.commit()
 
 
@@ -193,11 +186,11 @@ def getBasicStats(top_media_number=5, top_username_number=5):
 
         cur.execute("SELECT COUNT(1) FROM comments")
         totalComments = int(cur.fetchone()[0])
-        basicStatDict['totalComments'] = totalComments
+        basicStatDict["totalComments"] = totalComments
 
         cur.execute("SELECT COUNT(1) FROM requests;")
         total = int(cur.fetchone()[0])
-        basicStatDict['total'] = total
+        basicStatDict["total"] = total
 
         cur.execute(
             """
@@ -207,7 +200,7 @@ def getBasicStats(top_media_number=5, top_username_number=5):
             """
         )
         dNames = int(cur.fetchone()[0])
-        basicStatDict['uniqueNames'] = dNames
+        basicStatDict["uniqueNames"] = dNames
 
         cur.execute(
             """
@@ -217,10 +210,10 @@ def getBasicStats(top_media_number=5, top_username_number=5):
             """
         )
         dSubreddits = int(cur.fetchone()[0])
-        basicStatDict['uniqueSubreddits'] = dSubreddits
+        basicStatDict["uniqueSubreddits"] = dSubreddits
 
         meanValue = float(total) / dNames
-        basicStatDict['meanValuePerRequest'] = meanValue
+        basicStatDict["meanValuePerRequest"] = meanValue
 
         variance = 0
         cur.execute("SELECT name, count(name) FROM requests GROUP by name")
@@ -229,7 +222,7 @@ def getBasicStats(top_media_number=5, top_username_number=5):
 
         variance = variance / dNames
         stdDev = sqrt(variance)
-        basicStatDict['standardDeviation'] = stdDev
+        basicStatDict["standardDeviation"] = stdDev
 
         select_top_requests = """
         SELECT name, type, COUNT(name)
@@ -241,9 +234,9 @@ def getBasicStats(top_media_number=5, top_username_number=5):
 
         cur.execute(select_top_requests, top_request_values)
         topRequests = cur.fetchall()
-        basicStatDict['topRequests'] = []
+        basicStatDict["topRequests"] = []
         for request in topRequests:
-            basicStatDict['topRequests'].append(request)
+            basicStatDict["topRequests"].append(request)
 
         select_top_requesters = """
         SELECT requester, COUNT(requester)
@@ -255,16 +248,16 @@ def getBasicStats(top_media_number=5, top_username_number=5):
 
         cur.execute(select_top_requesters, top_requester_values)
         topRequesters = cur.fetchall()
-        basicStatDict['topRequesters'] = []
+        basicStatDict["topRequesters"] = []
         for requester in topRequesters:
-            basicStatDict['topRequesters'].append(requester)
+            basicStatDict["topRequesters"].append(requester)
 
         conn.commit()
         return basicStatDict
 
     except Exception:
         traceback.print_exc()
-        cur.execute('ROLLBACK')
+        cur.execute("ROLLBACK")
         conn.commit()
         return None
 
@@ -292,7 +285,7 @@ def getRequestStats(requestName, type):
 
         cur.execute(select_request_total, request_total_values)
         requestTotal = int(cur.fetchone()[0])
-        basicRequestDict['total'] = requestTotal
+        basicRequestDict["total"] = requestTotal
 
         if requestTotal == 0:
             return None
@@ -307,16 +300,16 @@ def getRequestStats(requestName, type):
 
         cur.execute(select_unique_subreddits, unique_subreddit_values)
         dSubreddits = int(cur.fetchone()[0])
-        basicRequestDict['uniqueSubreddits'] = dSubreddits
+        basicRequestDict["uniqueSubreddits"] = dSubreddits
 
         totalAsPercentage = (float(requestTotal) / total) * 100
-        basicRequestDict['totalAsPercentage'] = totalAsPercentage
+        basicRequestDict["totalAsPercentage"] = totalAsPercentage
 
         conn.commit()
         return basicRequestDict
 
     except Exception:
-        cur.execute('ROLLBACK')
+        cur.execute("ROLLBACK")
         conn.commit()
         return None
 
@@ -343,10 +336,7 @@ def getUserStats(username, top_media_number=5):
         # ---- Get total comments. --------------------------------------------
         cur.execute("SELECT COUNT(1) FROM comments")
         totalNumComments = int(cur.fetchone()[0])
-        totalUserCommentsAsPercentage = _percentage(
-            totalUserComments,
-            totalNumComments
-        )
+        totalUserCommentsAsPercentage = _percentage(totalUserComments, totalNumComments)
 
         # ---- Get total user requests. ---------------------------------------
         select_total_user_requests = """
@@ -362,10 +352,7 @@ def getUserStats(username, top_media_number=5):
         # ---- Get total requests. --------------------------------------------
         cur.execute("SELECT COUNT(1) FROM requests")
         totalNumRequests = int(cur.fetchone()[0])
-        totalUserRequestsAsPercentage = _percentage(
-            totalUserRequests,
-            totalNumRequests
-        )
+        totalUserRequestsAsPercentage = _percentage(totalUserRequests, totalNumRequests)
 
         # ---- Get overall request rank. --------------------------------------
         select_overall_request_rank = """
@@ -406,17 +393,13 @@ def getUserStats(username, top_media_number=5):
         """
         favourite_subreddit_stats_values = (username,)
 
-        cur.execute(
-            select_favourite_subreddit_stats,
-            favourite_subreddit_stats_values
-        )
+        cur.execute(select_favourite_subreddit_stats, favourite_subreddit_stats_values)
         favouriteSubredditStats = cur.fetchone()
         favouriteSubreddit = str(favouriteSubredditStats[0])
         favouriteSubredditCount = int(favouriteSubredditStats[1])
         favouriteSubredditOverallCount = int(favouriteSubredditStats[2])
         favouriteSubredditCountAsPercentage = _percentage(
-            favouriteSubredditCount,
-            favouriteSubredditOverallCount
+            favouriteSubredditCount, favouriteSubredditOverallCount
         )
 
         # ---- Get top requests. ----------------------------------------------
@@ -435,7 +418,7 @@ def getUserStats(username, top_media_number=5):
         conn.commit()
 
     except Exception:
-        cur.execute('ROLLBACK')
+        cur.execute("ROLLBACK")
         conn.commit()
         return None
 
@@ -453,11 +436,7 @@ def getUserStats(username, top_media_number=5):
     )
 
 
-def getSubredditStats(
-    subredditName,
-    top_media_number=5,
-    top_username_number=5
-):
+def getSubredditStats(subredditName, top_media_number=5, top_username_number=5):
     """
     Similar to getBasicStats - returns an object which contains data about a
     specific subreddit.
@@ -522,7 +501,7 @@ def getSubredditStats(
 
         cur.execute(
             select_subreddit_requests_by_name_and_type,
-            subreddit_requests_by_name_and_type_values
+            subreddit_requests_by_name_and_type_values,
         )
         for entry in cur.fetchall():
             variance += (entry[2] - meanValue) * (entry[2] - meanValue)
@@ -559,7 +538,7 @@ def getSubredditStats(
         conn.commit()
 
     except Exception:
-        cur.execute('ROLLBACK')
+        cur.execute("ROLLBACK")
         conn.commit()
         return None
 

--- a/roboragi/Kitsu.py
+++ b/roboragi/Kitsu.py
@@ -17,21 +17,21 @@ import difflib
 
 import requests
 
-AUTH_URL = 'https://kitsu.io/api/oauth/'
-BASE_URL = 'https://kitsu.io/api/edge/'
-ANIME_SEARCH_FILTER = 'anime?filter[text]='
-MANGA_SEARCH_FILTER = 'manga?filter[text]='
-ANIME_GET_FILTER = 'anime?filter[slug]='
-MANGA_GET_FILTER = 'manga?filter[slug]='
+AUTH_URL = "https://kitsu.io/api/oauth/"
+BASE_URL = "https://kitsu.io/api/edge/"
+ANIME_SEARCH_FILTER = "anime?filter[text]="
+MANGA_SEARCH_FILTER = "manga?filter[text]="
+ANIME_GET_FILTER = "anime?filter[slug]="
+MANGA_GET_FILTER = "manga?filter[slug]="
 
-ENGLISH_LANGUAGE_CODES = ['en', 'en_us']
-ROMAJI_LANGUAGE_CODES = ['en_jp']
-JAPANESE_LANGUAGE_CODES = ['ja_jp']
+ENGLISH_LANGUAGE_CODES = ["en", "en_us"]
+ROMAJI_LANGUAGE_CODES = ["en_jp"]
+JAPANESE_LANGUAGE_CODES = ["ja_jp"]
 
 session = requests.Session()
 session.headers = {
-    'Accept': 'application/vnd.api+json',
-    'Content-Type': 'application/vnd.api+json'
+    "Accept": "application/vnd.api+json",
+    "Content-Type": "application/vnd.api+json",
 }
 
 
@@ -40,7 +40,7 @@ def search(endpoint, search_term, parser, use_first_result=False):
         response = session.get(BASE_URL + endpoint + search_term, timeout=4)
         response.raise_for_status()
 
-        results = parser(response.json()['data'])
+        results = parser(response.json()["data"])
 
         if not results:
             return None
@@ -66,22 +66,19 @@ def get_closest(results, search_term):
             name_list.extend(synonyms)
 
     matches = difflib.get_close_matches(
-        word=search_term.lower(),
-        possibilities=name_list,
-        n=1,
-        cutoff=0.90
+        word=search_term.lower(), possibilities=name_list, n=1, cutoff=0.90
     )
     closest_name_from_list = matches[0].lower()
 
     for result in results:
-        if result['title_romaji']:
-            if result['title_romaji'].lower() == closest_name_from_list:
+        if result["title_romaji"]:
+            if result["title_romaji"].lower() == closest_name_from_list:
                 return result
-        elif result['title_english']:
-            if result['title_english'].lower() == closest_name_from_list:
+        elif result["title_english"]:
+            if result["title_english"].lower() == closest_name_from_list:
                 return result
         else:
-            for synonym in result['synonyms']:
+            for synonym in result["synonyms"]:
                 if synonym.lower() == closest_name_from_list:
                     return result
 
@@ -124,35 +121,35 @@ def parse_anime(results):
 
     for entry in results:
         try:
-            id_ = entry['id']
-            slug = entry['attributes']['slug']
+            id_ = entry["id"]
+            slug = entry["attributes"]["slug"]
             url = f"https://kitsu.io/anime/{slug}"
             title_romaji = get_title_by_language_codes(
-                titles=entry['attributes']['titles'],
-                language_codes=ROMAJI_LANGUAGE_CODES
+                titles=entry["attributes"]["titles"],
+                language_codes=ROMAJI_LANGUAGE_CODES,
             )
             title_english = get_title_by_language_codes(
-                titles=entry['attributes']['titles'],
-                language_codes=ENGLISH_LANGUAGE_CODES
+                titles=entry["attributes"]["titles"],
+                language_codes=ENGLISH_LANGUAGE_CODES,
             )
             title_japanese = get_title_by_language_codes(
-                titles=entry['attributes']['titles'],
-                language_codes=JAPANESE_LANGUAGE_CODES
+                titles=entry["attributes"]["titles"],
+                language_codes=JAPANESE_LANGUAGE_CODES,
             )
 
-            if entry['attributes']['abbreviatedTitles']:
-                synonyms = set(entry['attributes']['abbreviatedTitles'])
+            if entry["attributes"]["abbreviatedTitles"]:
+                synonyms = set(entry["attributes"]["abbreviatedTitles"])
             else:
                 synonyms = set()
 
-            if entry['attributes']['episodeCount']:
-                episode_count = int(entry['attributes']['episodeCount'])
+            if entry["attributes"]["episodeCount"]:
+                episode_count = int(entry["attributes"]["episodeCount"])
             else:
                 episode_count = None
 
-            type_ = entry['attributes']['showType']
-            description = entry['attributes']['synopsis']
-            nsfw = entry['attributes']['nsfw']
+            type_ = entry["attributes"]["showType"]
+            description = entry["attributes"]["synopsis"]
+            nsfw = entry["attributes"]["nsfw"]
 
             anime = dict(
                 id=id_,
@@ -179,39 +176,39 @@ def parse_manga(results):
 
     for entry in results:
         try:
-            type_ = entry['attributes']['mangaType']
+            type_ = entry["attributes"]["mangaType"]
             # Avoid all the processsing below if the type is "novel".
-            if type_.lower() == 'novel':
+            if type_.lower() == "novel":
                 continue
 
-            id_ = entry['id']
-            slug = entry['attributes']['slug']
+            id_ = entry["id"]
+            slug = entry["attributes"]["slug"]
             url = f"https://kitsu.io/manga/{slug}"
             title_romaji = get_title_by_language_codes(
-                titles=entry['attributes']['titles'],
-                language_codes=ROMAJI_LANGUAGE_CODES
+                titles=entry["attributes"]["titles"],
+                language_codes=ROMAJI_LANGUAGE_CODES,
             )
             title_english = get_title_by_language_codes(
-                titles=entry['attributes']['titles'],
-                language_codes=ENGLISH_LANGUAGE_CODES
+                titles=entry["attributes"]["titles"],
+                language_codes=ENGLISH_LANGUAGE_CODES,
             )
 
-            if entry['attributes']['abbreviatedTitles']:
-                synonyms = set(entry['attributes']['abbreviatedTitles'])
+            if entry["attributes"]["abbreviatedTitles"]:
+                synonyms = set(entry["attributes"]["abbreviatedTitles"])
             else:
                 synonyms = set()
 
-            if entry['attributes']['volumeCount']:
-                volume_count = int(entry['attributes']['volumeCount'])
+            if entry["attributes"]["volumeCount"]:
+                volume_count = int(entry["attributes"]["volumeCount"])
             else:
                 volume_count = None
 
-            if entry['attributes']['chapterCount']:
-                chapter_count = int(entry['attributes']['chapterCount'])
+            if entry["attributes"]["chapterCount"]:
+                chapter_count = int(entry["attributes"]["chapterCount"])
             else:
                 chapter_count = None
 
-            description = entry['attributes']['synopsis']
+            description = entry["attributes"]["synopsis"]
 
             manga = dict(
                 id=id_,
@@ -221,7 +218,7 @@ def parse_manga(results):
                 synonyms=synonyms,
                 volume_count=volume_count,
                 chapter_count=chapter_count,
-                type=entry['attributes']['mangaType'],
+                type=entry["attributes"]["mangaType"],
                 description=description,
             )
 
@@ -237,39 +234,39 @@ def parse_light_novel(results):
 
     for entry in results:
         try:
-            type_ = entry['attributes']['mangaType']
+            type_ = entry["attributes"]["mangaType"]
             # Avoid all the processsing below if the type is not "novel".
-            if type_.lower() != 'novel':
+            if type_.lower() != "novel":
                 continue
 
-            id_ = entry['id']
-            slug = entry['attributes']['slug']
+            id_ = entry["id"]
+            slug = entry["attributes"]["slug"]
             url = f"https://kitsu.io/manga/{slug}"
             title_romaji = get_title_by_language_codes(
-                titles=entry['attributes']['titles'],
-                language_codes=ROMAJI_LANGUAGE_CODES
+                titles=entry["attributes"]["titles"],
+                language_codes=ROMAJI_LANGUAGE_CODES,
             )
             title_english = get_title_by_language_codes(
-                titles=entry['attributes']['titles'],
-                language_codes=ENGLISH_LANGUAGE_CODES
+                titles=entry["attributes"]["titles"],
+                language_codes=ENGLISH_LANGUAGE_CODES,
             )
 
-            if entry['attributes']['abbreviatedTitles']:
-                synonyms = set(entry['attributes']['abbreviatedTitles'])
+            if entry["attributes"]["abbreviatedTitles"]:
+                synonyms = set(entry["attributes"]["abbreviatedTitles"])
             else:
                 synonyms = set()
 
-            if entry['attributes']['volumeCount']:
-                volume_count = int(entry['attributes']['volumeCount'])
+            if entry["attributes"]["volumeCount"]:
+                volume_count = int(entry["attributes"]["volumeCount"])
             else:
                 volume_count = None
 
-            if entry['attributes']['chapterCount']:
-                chapter_count = int(entry['attributes']['chapterCount'])
+            if entry["attributes"]["chapterCount"]:
+                chapter_count = int(entry["attributes"]["chapterCount"])
             else:
                 chapter_count = None
 
-            description = entry['attributes']['synopsis']
+            description = entry["attributes"]["synopsis"]
 
             ln = dict(
                 id=id_,
@@ -292,14 +289,14 @@ def parse_light_novel(results):
 
 def get_synonyms(result):
     synonyms = set()
-    synonyms.update(result['synonyms'])
+    synonyms.update(result["synonyms"])
     return synonyms
 
 
 def get_titles(result):
     titles = set()
-    titles.add(result['title_romaji']) if result['title_romaji'] else None
-    titles.add(result['title_english']) if result['title_english'] else None
+    titles.add(result["title_romaji"]) if result["title_romaji"] else None
+    titles.add(result["title_english"]) if result["title_english"] else None
     return titles
 
 

--- a/roboragi/LNDB.py
+++ b/roboragi/LNDB.py
@@ -1,7 +1,7 @@
-'''
+"""
 LNDB.py
 Handles all LNDB information
-'''
+"""
 
 # Copyright (C) 2018  Nihilate
 #
@@ -28,16 +28,13 @@ req = requests.Session()
 
 def getLightNovelURL(searchText):
     try:
-        searchText = searchText.replace(' ', '+')
-        html = req.get(
-            url=f"http://lndb.info/search?text={searchText}",
-            timeout=10
-        )
+        searchText = searchText.replace(" ", "+")
+        html = req.get(url=f"http://lndb.info/search?text={searchText}", timeout=10)
         req.close()
 
         lndb = pq(html.text)
 
-        if 'light_novel' in html.url:
+        if "light_novel" in html.url:
             # we've immediately hit a result
             return html.url
         else:
@@ -45,17 +42,16 @@ def getLightNovelURL(searchText):
 
             lnList = []
 
-            for thing in lndb.find('#bodylightnovelscontentid table tr'):
-                title = pq(thing).find('a').text()
-                url = pq(thing).find('a').attr('href')
+            for thing in lndb.find("#bodylightnovelscontentid table tr"):
+                title = pq(thing).find("a").text()
+                url = pq(thing).find("a").attr("href")
 
                 if title:
-                    data = {'title': title,
-                            'url': url}
+                    data = {"title": title, "url": url}
                     lnList.append(data)
 
             closest = findClosestLightNovel(searchText, lnList)
-            return closest['url']
+            return closest["url"]
 
     except Exception:
         req.close()
@@ -67,17 +63,14 @@ def findClosestLightNovel(searchText, lnList):
         nameList = []
 
         for ln in lnList:
-            nameList.append(ln['title'].lower())
+            nameList.append(ln["title"].lower())
 
         closestNameFromList = difflib.get_close_matches(
-            word=searchText.lower(),
-            possibilities=nameList,
-            n=1,
-            cutoff=0.80
+            word=searchText.lower(), possibilities=nameList, n=1, cutoff=0.80
         )
 
         for ln in lnList:
-            if ln['title'].lower() == closestNameFromList[0].lower():
+            if ln["title"].lower() == closestNameFromList[0].lower():
                 return ln
 
         return None
@@ -86,4 +79,4 @@ def findClosestLightNovel(searchText, lnList):
 
 
 def getLightNovelById(lnId):
-    return 'http://lndb.info/light_novel/' + str(lnId)
+    return "http://lndb.info/light_novel/" + str(lnId)

--- a/roboragi/MU.py
+++ b/roboragi/MU.py
@@ -1,7 +1,7 @@
-'''
+"""
 MU.py
 Handles all MangaUpdates information
-'''
+"""
 
 # Copyright (C) 2018  Nihilate
 #
@@ -31,17 +31,14 @@ def findClosestManga(searchText, mangaList):
         nameList = []
 
         for manga in mangaList:
-            nameList.append(manga['title'].lower())
+            nameList.append(manga["title"].lower())
 
         closestNameFromList = difflib.get_close_matches(
-            word=searchText.lower(),
-            possibilities=nameList,
-            n=1,
-            cutoff=0.85
+            word=searchText.lower(), possibilities=nameList, n=1, cutoff=0.85
         )
 
         for manga in mangaList:
-            if manga['title'].lower() == closestNameFromList[0].lower():
+            if manga["title"].lower() == closestNameFromList[0].lower():
                 return manga
 
         return None
@@ -51,11 +48,9 @@ def findClosestManga(searchText, mangaList):
 
 def getMangaURL(searchText):
     try:
-        payload = {'search': searchText}
+        payload = {"search": searchText}
         html = req.get(
-            url='https://mangaupdates.com/series.html',
-            params=payload,
-            timeout=10
+            url="https://mangaupdates.com/series.html", params=payload, timeout=10
         )
         req.close()
 
@@ -63,24 +58,26 @@ def getMangaURL(searchText):
 
         mangaList = []
 
-        for thing in mu.find('.series_rows_table tr'):
-            title = pq(thing).find('.col1').text()
-            url = pq(thing).find('.col1 a').attr('href')
-            genres = pq(thing).find('.col2').text()
-            year = pq(thing).find('.col3').text()
-            rating = pq(thing).find('.col4').text()
+        for thing in mu.find(".series_rows_table tr"):
+            title = pq(thing).find(".col1").text()
+            url = pq(thing).find(".col1 a").attr("href")
+            genres = pq(thing).find(".col2").text()
+            year = pq(thing).find(".col3").text()
+            rating = pq(thing).find(".col4").text()
 
             if title:
-                data = {'title': title,
-                        'url': url,
-                        'genres': genres,
-                        'year': year,
-                        'rating': rating}
+                data = {
+                    "title": title,
+                    "url": url,
+                    "genres": genres,
+                    "year": year,
+                    "rating": rating,
+                }
 
                 mangaList.append(data)
 
         closest = findClosestManga(searchText, mangaList)
-        return closest['url']
+        return closest["url"]
 
     except Exception:
         req.close()
@@ -88,4 +85,4 @@ def getMangaURL(searchText):
 
 
 def getMangaURLById(mangaId):
-    return 'https://www.mangaupdates.com/series.html?id=' + str(mangaId)
+    return "https://www.mangaupdates.com/series.html?id=" + str(mangaId)

--- a/roboragi/NU.py
+++ b/roboragi/NU.py
@@ -1,7 +1,7 @@
-'''
+"""
 NovelUpdates.py
 Handles all NovelUpdates information
-'''
+"""
 
 # Copyright (C) 2018  Nihilate
 #
@@ -28,10 +28,9 @@ req = requests.Session()
 
 def getLightNovelURL(searchText):
     try:
-        searchText = searchText.replace(' ', '+')
+        searchText = searchText.replace(" ", "+")
         html = requests.get(
-            url=f"http://www.novelupdates.com/?s={searchText}",
-            timeout=10
+            url=f"http://www.novelupdates.com/?s={searchText}", timeout=10
         )
         req.close()
 
@@ -39,17 +38,16 @@ def getLightNovelURL(searchText):
 
         lnList = []
 
-        for thing in nu.find('.w-blog-entry'):
-            title = pq(thing).find('.w-blog-entry-title').text()
-            url = pq(thing).find('.w-blog-entry-link').attr('href')
+        for thing in nu.find(".w-blog-entry"):
+            title = pq(thing).find(".w-blog-entry-title").text()
+            url = pq(thing).find(".w-blog-entry-link").attr("href")
 
             if title:
-                data = {'title': title,
-                        'url': url}
+                data = {"title": title, "url": url}
                 lnList.append(data)
 
         closest = findClosestLightNovel(searchText, lnList)
-        return closest['url']
+        return closest["url"]
 
     except Exception:
         req.close()
@@ -62,21 +60,16 @@ def findClosestLightNovel(searchText, lnList):
         nameListWithoutWN = []
 
         for ln in lnList:
-            nameList.append(ln['title'].lower())
+            nameList.append(ln["title"].lower())
 
-            if '(wn)' not in ln['title'].lower():
-                nameListWithoutWN.append(ln['title'].lower())
+            if "(wn)" not in ln["title"].lower():
+                nameListWithoutWN.append(ln["title"].lower())
 
         closestNameFromListWithoutWN = difflib.get_close_matches(
-            word=searchText.lower(),
-            possibilities=nameListWithoutWN,
-            n=1,
-            cutoff=0.80
+            word=searchText.lower(), possibilities=nameListWithoutWN, n=1, cutoff=0.80
         )
         closestNameFromListWithWN = difflib.get_close_matches(
-            word=searchText.lower(), possibilities=nameList,
-            n=1,
-            cutoff=0.80
+            word=searchText.lower(), possibilities=nameList, n=1, cutoff=0.80
         )
 
         if closestNameFromListWithoutWN:
@@ -85,7 +78,7 @@ def findClosestLightNovel(searchText, lnList):
             nameToUse = closestNameFromListWithWN[0].lower()
 
         for ln in lnList:
-            if ln['title'].lower() == nameToUse:
+            if ln["title"].lower() == nameToUse:
                 return ln
 
         return None
@@ -94,4 +87,4 @@ def findClosestLightNovel(searchText, lnList):
 
 
 def getLightNovelById(lnId):
-    return 'http://www.novelupdates.com/series/' + str(lnId)
+    return "http://www.novelupdates.com/series/" + str(lnId)

--- a/roboragi/Reference.py
+++ b/roboragi/Reference.py
@@ -17,7 +17,7 @@
 
 import sqlite3
 
-sqlConn = sqlite3.connect('reference.db')
+sqlConn = sqlite3.connect("reference.db")
 sqlCur = sqlConn.cursor()
 
 
@@ -37,6 +37,6 @@ def is_april_fools_2016(username):
 
 def get_bling(username):
     if is_april_fools_2016(username):
-        return '&#32;|&#32;\U0001F4B0'
+        return "&#32;|&#32;\U0001F4B0"
     else:
-        return ''
+        return ""

--- a/roboragi/Search.py
+++ b/roboragi/Search.py
@@ -1,8 +1,8 @@
-'''
+"""
 Search.py
 Returns a built comment created from multiple databases when given a search
 term.
-'''
+"""
 
 # Copyright (C) 2018  Nihilate
 #
@@ -33,7 +33,7 @@ import MU
 import NU
 from VNDB import VNDB
 
-USERNAME = ''
+USERNAME = ""
 
 try:
     import Config
@@ -42,14 +42,16 @@ try:
 except ImportError:
     pass
 
-sqlConn = sqlite3.connect('synonyms.db')
+sqlConn = sqlite3.connect("synonyms.db")
 sqlCur = sqlConn.cursor()
 
 try:
-    query = ('SELECT dbLinks'
-             '  FROM synonyms'
-             ' WHERE type = "Manga"'
-             '   AND lower(name) = ?;')
+    query = (
+        "SELECT dbLinks"
+        "  FROM synonyms"
+        ' WHERE type = "Manga"'
+        "   AND lower(name) = ?;"
+    )
     sqlCur.execute(query, ["despair simulator"])
 except sqlite3.Error as e:
     print(e)
@@ -58,59 +60,63 @@ except sqlite3.Error as e:
 def buildMangaReply(searchText, isExpanded, baseComment, blockTracking=False):
     """ Builds a manga reply from multiple sources """
     try:
-        ani = {'search_function': Anilist.getMangaDetails,
-               'title_function': Anilist.getTitles,
-               'synonym_function': Anilist.getSynonyms,
-               'checked_synonyms': [],
-               'result': None}
-        kit = {'search_function': Kitsu.search_manga,
-               'synonym_function': Kitsu.get_synonyms,
-               'title_function': Kitsu.get_titles,
-               'checked_synonyms': [],
-               'result': None}
-        mu = {'search_function': MU.getMangaURL,
-              'result': None}
-        ap = {'search_function': AniP.getMangaURL,
-              'result': None}
+        ani = {
+            "search_function": Anilist.getMangaDetails,
+            "title_function": Anilist.getTitles,
+            "synonym_function": Anilist.getSynonyms,
+            "checked_synonyms": [],
+            "result": None,
+        }
+        kit = {
+            "search_function": Kitsu.search_manga,
+            "synonym_function": Kitsu.get_synonyms,
+            "title_function": Kitsu.get_titles,
+            "checked_synonyms": [],
+            "result": None,
+        }
+        mu = {"search_function": MU.getMangaURL, "result": None}
+        ap = {"search_function": AniP.getMangaURL, "result": None}
 
         try:
-            query = ('SELECT dbLinks'
-                     '  FROM synonyms'
-                     ' WHERE type = "Manga"'
-                     '   AND lower(name) = ?')
+            query = (
+                "SELECT dbLinks"
+                "  FROM synonyms"
+                ' WHERE type = "Manga"'
+                "   AND lower(name) = ?"
+            )
             sqlCur.execute(query, [searchText.lower()])
         except sqlite3.Error as e:
             print(e)
 
         alternateLinks = sqlCur.fetchone()
 
-        if (alternateLinks):
+        if alternateLinks:
             synonym = json.loads(alternateLinks[0])
 
             if synonym:
                 anisyn = None
-                if 'ani' in synonym and synonym['ani']:
-                    anisyn = synonym['ani']
+                if "ani" in synonym and synonym["ani"]:
+                    anisyn = synonym["ani"]
 
                 kitsyn = None
-                if 'kit' in synonym and synonym['kit']:
-                    kitsyn = synonym['kit']
+                if "kit" in synonym and synonym["kit"]:
+                    kitsyn = synonym["kit"]
 
                 musyn = None
-                if 'mu' in synonym and synonym['mu']:
-                    musyn = synonym['mu']
+                if "mu" in synonym and synonym["mu"]:
+                    musyn = synonym["mu"]
 
                 apsyn = None
-                if 'ap' in synonym and synonym['ap']:
-                    apsyn = synonym['ap']
+                if "ap" in synonym and synonym["ap"]:
+                    apsyn = synonym["ap"]
 
                 if anisyn:
-                    ani['result'] = Anilist.getMangaDetailsById(anisyn)
+                    ani["result"] = Anilist.getMangaDetailsById(anisyn)
                 else:
-                    ani['result'] = None
-                kit['result'] = Kitsu.get_manga(kitsyn) if kitsyn else None
-                mu['result'] = MU.getMangaURLById(musyn) if musyn else None
-                ap['result'] = AniP.getMangaURLById(apsyn) if apsyn else None
+                    ani["result"] = None
+                kit["result"] = Kitsu.get_manga(kitsyn) if kitsyn else None
+                mu["result"] = MU.getMangaURLById(musyn) if musyn else None
+                ap["result"] = AniP.getMangaURLById(apsyn) if apsyn else None
 
         else:
             data_sources = [ani, kit]
@@ -121,98 +127,94 @@ def buildMangaReply(searchText, isExpanded, baseComment, blockTracking=False):
 
             for x in range(len(data_sources)):
                 for source in data_sources:
-                    if source['result']:
+                    if source["result"]:
                         break
                     else:
                         for title in titles:
-                            if title in source['checked_synonyms']:
+                            if title in source["checked_synonyms"]:
                                 break
 
-                            if source['result']:
+                            if source["result"]:
                                 break
 
-                            source['result'] = source['search_function'](title)
-                            source['checked_synonyms'].append(title)
+                            source["result"] = source["search_function"](title)
+                            source["checked_synonyms"].append(title)
 
-                            if source['result']:
+                            if source["result"]:
                                 break
 
                         for synonym in synonyms:
-                            if synonym in source['checked_synonyms']:
+                            if synonym in source["checked_synonyms"]:
                                 break
 
-                            if source['result']:
+                            if source["result"]:
                                 break
 
-                            search_function = source['search_function']
-                            source['result'] = search_function(synonym)
-                            source['checked_synonyms'].append(synonym)
+                            search_function = source["search_function"]
+                            source["result"] = search_function(synonym)
+                            source["checked_synonyms"].append(synonym)
 
-                            if source['result']:
+                            if source["result"]:
                                 break
 
-                    if source['result']:
-                        result = source['result']
-                        synonym_function = source['synonym_function']
-                        title_function = source['title_function']
-                        synonyms.update(
-                            [s.lower() for s in synonym_function(result)]
-                        )
-                        titles.update(
-                            [t.lower() for t in title_function(result)]
-                        )
+                    if source["result"]:
+                        result = source["result"]
+                        synonym_function = source["synonym_function"]
+                        title_function = source["title_function"]
+                        synonyms.update([s.lower() for s in synonym_function(result)])
+                        titles.update([t.lower() for t in title_function(result)])
 
             for source in aux_sources:
                 for title in titles:
-                    source['result'] = source['search_function'](synonym)
+                    source["result"] = source["search_function"](synonym)
 
-                    if source['result']:
+                    if source["result"]:
                         break
 
-                if not source['result']:
+                if not source["result"]:
                     for synonym in synonyms:
-                        source['result'] = source['search_function'](synonym)
+                        source["result"] = source["search_function"](synonym)
 
-                        if source['result']:
+                        if source["result"]:
                             break
 
-        if ani['result'] or kit['result']:
+        if ani["result"] or kit["result"]:
             try:
-                titleToAdd = ''
-                if ani['result']:
+                titleToAdd = ""
+                if ani["result"]:
                     try:
-                        titleToAdd = ani['result']['title_romaji']
+                        titleToAdd = ani["result"]["title_romaji"]
                     except Exception:
-                        titleToAdd = ani['result']['title_english']
-                elif kit['result']:
+                        titleToAdd = ani["result"]["title_english"]
+                elif kit["result"]:
                     try:
-                        titleToAdd = kit['result']['title_romaji']
+                        titleToAdd = kit["result"]["title_romaji"]
                     except Exception:
-                        titleToAdd = kit['result']['title_english']
+                        titleToAdd = kit["result"]["title_english"]
 
                 subreddit = str(baseComment.subreddit).lower
-                ignored_subreddits = ('nihilate', 'roboragi')
+                ignored_subreddits = ("nihilate", "roboragi")
                 if subreddit not in ignored_subreddits and not blockTracking:
                     DatabaseHandler.addRequest(
                         name=titleToAdd,
-                        rType='Manga',
+                        rType="Manga",
                         requester=baseComment.author.name,
-                        subreddit=baseComment.subreddit
+                        subreddit=baseComment.subreddit,
                     )
             except Exception:
                 traceback.print_exc()
                 pass
 
-        if ani['result'] or kit['result']:
+        if ani["result"] or kit["result"]:
             return CommentBuilder.buildMangaComment(
                 isExpanded=isExpanded,
-                ani=ani['result'],
-                mu=mu['result'],
-                ap=ap['result'],
-                kit=kit['result']
+                ani=ani["result"],
+                mu=mu["result"],
+                ap=ap["result"],
+                kit=kit["result"],
             )
         else:
-            print('No result found for ' + searchText)
+            print("No result found for " + searchText)
             return None
 
     except Exception:
@@ -223,54 +225,59 @@ def buildMangaReply(searchText, isExpanded, baseComment, blockTracking=False):
 def buildAnimeReply(searchText, isExpanded, baseComment, blockTracking=False):
     """ Builds an anime reply from multiple sources """
     try:
-        kit = {'search_function': Kitsu.search_anime,
-               'synonym_function': Kitsu.get_synonyms,
-               'title_function': Kitsu.get_titles,
-               'checked_synonyms': [],
-               'result': None}
-        ani = {'search_function': Anilist.getAnimeDetails,
-               'synonym_function': Anilist.getSynonyms,
-               'title_function': Anilist.getTitles,
-               'checked_synonyms': [],
-               'result': None}
-        ap = {'search_function': AniP.getAnimeURL,
-              'result': None}
+        kit = {
+            "search_function": Kitsu.search_anime,
+            "synonym_function": Kitsu.get_synonyms,
+            "title_function": Kitsu.get_titles,
+            "checked_synonyms": [],
+            "result": None,
+        }
+        ani = {
+            "search_function": Anilist.getAnimeDetails,
+            "synonym_function": Anilist.getSynonyms,
+            "title_function": Anilist.getTitles,
+            "checked_synonyms": [],
+            "result": None,
+        }
+        ap = {"search_function": AniP.getAnimeURL, "result": None}
 
         try:
-            query = ('SELECT dbLinks'
-                     '  FROM synonyms'
-                     ' WHERE type = "Anime"'
-                     '   AND lower(name) = ?')
+            query = (
+                "SELECT dbLinks"
+                "  FROM synonyms"
+                ' WHERE type = "Anime"'
+                "   AND lower(name) = ?"
+            )
             sqlCur.execute(query, [searchText.lower()])
         except sqlite3.Error as e:
             print(e)
 
         alternateLinks = sqlCur.fetchone()
 
-        if (alternateLinks):
+        if alternateLinks:
             synonym = json.loads(alternateLinks[0])
 
             if synonym:
                 kitsyn = None
-                if 'kit' in synonym and synonym['kit']:
-                    kitsyn = synonym['kit']
+                if "kit" in synonym and synonym["kit"]:
+                    kitsyn = synonym["kit"]
 
                 anisyn = None
-                if 'ani' in synonym and synonym['ani']:
-                    anisyn = synonym['ani']
+                if "ani" in synonym and synonym["ani"]:
+                    anisyn = synonym["ani"]
 
                 apsyn = None
-                if 'ap' in synonym and synonym['ap']:
-                    apsyn = synonym['ap']
+                if "ap" in synonym and synonym["ap"]:
+                    apsyn = synonym["ap"]
 
-                kit['result'] = Kitsu.get_anime(kitsyn) if kitsyn else None
+                kit["result"] = Kitsu.get_anime(kitsyn) if kitsyn else None
 
                 if anisyn:
-                    ani['result'] = Anilist.getAnimeDetailsById(anisyn)
+                    ani["result"] = Anilist.getAnimeDetailsById(anisyn)
                 else:
-                    ani['result'] = None
+                    ani["result"] = None
 
-                ap['result'] = AniP.getAnimeURLById(apsyn) if apsyn else None
+                ap["result"] = AniP.getAnimeURLById(apsyn) if apsyn else None
 
         else:
             data_sources = [ani, kit]
@@ -281,77 +288,73 @@ def buildAnimeReply(searchText, isExpanded, baseComment, blockTracking=False):
 
             for x in range(len(data_sources)):
                 for source in data_sources:
-                    if source['result']:
+                    if source["result"]:
                         break
                     else:
-                        for synonym in (titles | synonyms):
-                            if synonym in source['checked_synonyms']:
+                        for synonym in titles | synonyms:
+                            if synonym in source["checked_synonyms"]:
                                 continue
 
-                            search_function = source['search_function']
-                            source['result'] = search_function(synonym)
-                            source['checked_synonyms'].append(synonym)
+                            search_function = source["search_function"]
+                            source["result"] = search_function(synonym)
+                            source["checked_synonyms"].append(synonym)
 
-                            if source['result']:
+                            if source["result"]:
                                 break
 
-                    if source['result']:
-                        result = source['result']
-                        synonym_function = source['synonym_function']
-                        title_function = source['title_function']
-                        synonyms.update(
-                            [s.lower() for s in synonym_function(result)]
-                        )
-                        titles.update(
-                            [t.lower() for t in title_function(result)]
-                        )
+                    if source["result"]:
+                        result = source["result"]
+                        synonym_function = source["synonym_function"]
+                        title_function = source["title_function"]
+                        synonyms.update([s.lower() for s in synonym_function(result)])
+                        titles.update([t.lower() for t in title_function(result)])
 
             for source in aux_sources:
                 for title in titles:
-                    source['result'] = source['search_function'](synonym)
+                    source["result"] = source["search_function"](synonym)
 
-                    if source['result']:
+                    if source["result"]:
                         break
 
-                if not source['result']:
+                if not source["result"]:
                     for synonym in synonyms:
-                        source['result'] = source['search_function'](synonym)
+                        source["result"] = source["search_function"](synonym)
 
-                        if source['result']:
+                        if source["result"]:
                             break
 
-        if ani['result'] or kit['result']:
+        if ani["result"] or kit["result"]:
             try:
-                titleToAdd = ''
-                if ani['result']:
-                    if 'title_romaji' in ani['result']:
-                        titleToAdd = ani['result']['title_romaji']
-                elif kit['result']:
-                    if 'title_romaji' in kit['result']:
-                        titleToAdd = kit['result']['title_romaji']
+                titleToAdd = ""
+                if ani["result"]:
+                    if "title_romaji" in ani["result"]:
+                        titleToAdd = ani["result"]["title_romaji"]
+                elif kit["result"]:
+                    if "title_romaji" in kit["result"]:
+                        titleToAdd = kit["result"]["title_romaji"]
 
                 subreddit = str(baseComment.subreddit).lower
-                ignored_subreddits = ('nihilate', 'roboragi')
+                ignored_subreddits = ("nihilate", "roboragi")
                 if subreddit not in ignored_subreddits and not blockTracking:
                     DatabaseHandler.addRequest(
                         name=titleToAdd,
-                        rType='Anime',
+                        rType="Anime",
                         requester=baseComment.author.name,
-                        subreddit=baseComment.subreddit
+                        subreddit=baseComment.subreddit,
                     )
             except Exception:
                 traceback.print_exc()
                 pass
 
-        if ani['result'] or kit['result']:
+        if ani["result"] or kit["result"]:
             return CommentBuilder.buildAnimeComment(
                 isExpanded=isExpanded,
-                ani=ani['result'],
-                ap=ap['result'],
-                kit=kit['result']
+                ani=ani["result"],
+                ap=ap["result"],
+                kit=kit["result"],
             )
         else:
-            print('No result found for ' + searchText)
+            print("No result found for " + searchText)
             return None
 
     except Exception:
@@ -359,72 +362,75 @@ def buildAnimeReply(searchText, isExpanded, baseComment, blockTracking=False):
         return None
 
 
-def buildLightNovelReply(searchText, isExpanded, baseComment,
-                         blockTracking=False):
+def buildLightNovelReply(searchText, isExpanded, baseComment, blockTracking=False):
     """ Builds an LN reply from multiple sources """
     try:
-        ani = {'search_function': Anilist.getLightNovelDetails,
-               'synonym_function': Anilist.getSynonyms,
-               'title_function': Anilist.getTitles,
-               'checked_synonyms': [],
-               'result': None}
-        kit = {'search_function': Kitsu.search_light_novel,
-               'synonym_function': Kitsu.get_synonyms,
-               'title_function': Kitsu.get_titles,
-               'checked_synonyms': [],
-               'result': None}
-        nu = {'search_function': NU.getLightNovelURL,
-              'result': None}
-        lndb = {'search_function': LNDB.getLightNovelURL,
-                'result': None}
+        ani = {
+            "search_function": Anilist.getLightNovelDetails,
+            "synonym_function": Anilist.getSynonyms,
+            "title_function": Anilist.getTitles,
+            "checked_synonyms": [],
+            "result": None,
+        }
+        kit = {
+            "search_function": Kitsu.search_light_novel,
+            "synonym_function": Kitsu.get_synonyms,
+            "title_function": Kitsu.get_titles,
+            "checked_synonyms": [],
+            "result": None,
+        }
+        nu = {"search_function": NU.getLightNovelURL, "result": None}
+        lndb = {"search_function": LNDB.getLightNovelURL, "result": None}
 
         try:
-            query = ('SELECT dbLinks'
-                     '  FROM synonyms'
-                     ' WHERE type = "LN"'
-                     '   AND lower(name) = ?')
+            query = (
+                "SELECT dbLinks"
+                "  FROM synonyms"
+                ' WHERE type = "LN"'
+                "   AND lower(name) = ?"
+            )
             sqlCur.execute(query, [searchText.lower()])
         except sqlite3.Error as e:
             print(e)
 
         alternateLinks = sqlCur.fetchone()
 
-        if (alternateLinks):
+        if alternateLinks:
             synonym = json.loads(alternateLinks[0])
 
             if synonym:
                 anisyn = None
-                if 'ani' in synonym and synonym['ani']:
-                    anisyn = synonym['ani']
+                if "ani" in synonym and synonym["ani"]:
+                    anisyn = synonym["ani"]
 
                 kitsyn = None
-                if 'kit' in synonym and synonym['kit']:
-                    kitsyn = synonym['kit']
+                if "kit" in synonym and synonym["kit"]:
+                    kitsyn = synonym["kit"]
 
                 nusyn = None
-                if 'nu' in synonym and synonym['nu']:
-                    nusyn = synonym['nu']
+                if "nu" in synonym and synonym["nu"]:
+                    nusyn = synonym["nu"]
 
                 lndbsyn = None
-                if 'lndb' in synonym and synonym['lndb']:
-                    lndbsyn = synonym['lndb']
+                if "lndb" in synonym and synonym["lndb"]:
+                    lndbsyn = synonym["lndb"]
 
                 if anisyn:
-                    ani['result'] = Anilist.getMangaDetailsById(anisyn)
+                    ani["result"] = Anilist.getMangaDetailsById(anisyn)
                 else:
-                    ani['result'] = None
+                    ani["result"] = None
 
                 if kitsyn:
-                    kit['result'] = Kitsu.get_light_novel(kitsyn)
+                    kit["result"] = Kitsu.get_light_novel(kitsyn)
                 else:
-                    kit['result'] = None
+                    kit["result"] = None
 
-                nu['result'] = NU.getLightNovelById(nusyn) if nusyn else None
+                nu["result"] = NU.getLightNovelById(nusyn) if nusyn else None
 
                 if lndbsyn:
-                    lndb['result'] = LNDB.getLightNovelById(lndbsyn)
+                    lndb["result"] = LNDB.getLightNovelById(lndbsyn)
                 else:
-                    lndb['result'] = None
+                    lndb["result"] = None
 
         else:
             data_sources = [ani, kit]
@@ -435,82 +441,78 @@ def buildLightNovelReply(searchText, isExpanded, baseComment,
 
             for x in range(len(data_sources)):
                 for source in data_sources:
-                    if source['result']:
+                    if source["result"]:
                         break
                     else:
-                        for synonym in (titles | synonyms):
-                            if synonym in source['checked_synonyms']:
+                        for synonym in titles | synonyms:
+                            if synonym in source["checked_synonyms"]:
                                 continue
 
-                            search_function = source['search_function']
-                            source['result'] = search_function(synonym)
-                            source['checked_synonyms'].append(synonym)
+                            search_function = source["search_function"]
+                            source["result"] = search_function(synonym)
+                            source["checked_synonyms"].append(synonym)
 
-                            if source['result']:
+                            if source["result"]:
                                 break
 
-                    if source['result']:
-                        result = source['result']
-                        synonym_function = source['synonym_function']
-                        title_function = source['title_function']
-                        synonyms.update(
-                            [s.lower() for s in synonym_function(result)]
-                        )
-                        titles.update(
-                            [t.lower() for t in title_function(result)]
-                        )
+                    if source["result"]:
+                        result = source["result"]
+                        synonym_function = source["synonym_function"]
+                        title_function = source["title_function"]
+                        synonyms.update([s.lower() for s in synonym_function(result)])
+                        titles.update([t.lower() for t in title_function(result)])
 
             for source in aux_sources:
                 for title in titles:
-                    source['result'] = source['search_function'](synonym)
+                    source["result"] = source["search_function"](synonym)
 
-                    if source['result']:
+                    if source["result"]:
                         break
 
-                if not source['result']:
+                if not source["result"]:
                     for synonym in synonyms:
-                        source['result'] = source['search_function'](synonym)
+                        source["result"] = source["search_function"](synonym)
 
-                        if source['result']:
+                        if source["result"]:
                             break
 
-        if ani['result'] or kit['result']:
+        if ani["result"] or kit["result"]:
             try:
-                titleToAdd = ''
-                if ani['result']:
+                titleToAdd = ""
+                if ani["result"]:
                     try:
-                        titleToAdd = ani['result']['title_romaji']
+                        titleToAdd = ani["result"]["title_romaji"]
                     except Exception:
-                        titleToAdd = ani['result']['title_english']
-                elif kit['result']:
+                        titleToAdd = ani["result"]["title_english"]
+                elif kit["result"]:
                     try:
-                        titleToAdd = kit['result']['title_romaji']
+                        titleToAdd = kit["result"]["title_romaji"]
                     except Exception:
-                        titleToAdd = kit['result']['title_english']
+                        titleToAdd = kit["result"]["title_english"]
 
                 subreddit = str(baseComment.subreddit).lower
-                ignored_subreddits = ('nihilate', 'roboragi')
+                ignored_subreddits = ("nihilate", "roboragi")
                 if subreddit not in ignored_subreddits and not blockTracking:
                     DatabaseHandler.addRequest(
                         name=titleToAdd,
-                        rType='LN',
+                        rType="LN",
                         requester=baseComment.author.name,
-                        subreddit=baseComment.subreddit
+                        subreddit=baseComment.subreddit,
                     )
             except Exception:
                 traceback.print_exc()
                 pass
 
-        if ani['result'] or kit['result']:
+        if ani["result"] or kit["result"]:
             return CommentBuilder.buildLightNovelComment(
                 isExpanded=isExpanded,
-                ani=ani['result'],
-                nu=nu['result'],
-                lndb=lndb['result'],
-                kit=kit['result']
+                ani=ani["result"],
+                nu=nu["result"],
+                lndb=lndb["result"],
+                kit=kit["result"],
             )
         else:
-            print('No result found for ' + searchText)
+            print("No result found for " + searchText)
             return None
 
     except Exception:
@@ -518,29 +520,30 @@ def buildLightNovelReply(searchText, isExpanded, baseComment,
         return None
 
 
-def buildVisualNovelReply(searchText, isExpanded, baseComment,
-                          blockTracking=False):
+def buildVisualNovelReply(searchText, isExpanded, baseComment, blockTracking=False):
     """ Builds an VN reply from VNDB """
     try:
         vndb = VNDB()
 
         try:
-            query = ('SELECT dbLinks'
-                     '  FROM synonyms'
-                     ' WHERE type = "VN"'
-                     '   AND lower(name) = ?')
+            query = (
+                "SELECT dbLinks"
+                "  FROM synonyms"
+                ' WHERE type = "VN"'
+                "   AND lower(name) = ?"
+            )
             sqlCur.execute(query, [searchText.lower()])
         except sqlite3.Error as e:
             print(e)
 
         alternateLinks = sqlCur.fetchone()
 
-        if (alternateLinks):
+        if alternateLinks:
             synonym = json.loads(alternateLinks[0])
 
             if synonym:
-                if 'vndb' in synonym and synonym['vndb']:
-                    synonym = synonym['vndb']
+                if "vndb" in synonym and synonym["vndb"]:
+                    synonym = synonym["vndb"]
 
                 if synonym:
                     result = vndb.getVisualNovelDetailsById(synonym)
@@ -554,16 +557,16 @@ def buildVisualNovelReply(searchText, isExpanded, baseComment,
 
         if result:
             try:
-                titleToAdd = result['title']
+                titleToAdd = result["title"]
 
                 subreddit = str(baseComment.subreddit).lower
-                ignored_subreddits = ('nihilate', 'roboragi')
+                ignored_subreddits = ("nihilate", "roboragi")
                 if subreddit not in ignored_subreddits and not blockTracking:
                     DatabaseHandler.addRequest(
                         name=titleToAdd,
-                        rType='VN',
+                        rType="VN",
                         requester=baseComment.author.name,
-                        subreddit=baseComment.subreddit
+                        subreddit=baseComment.subreddit,
                     )
             except Exception:
                 traceback.print_exc()
@@ -571,7 +574,7 @@ def buildVisualNovelReply(searchText, isExpanded, baseComment,
 
             return CommentBuilder.buildVisualNovelComment(isExpanded, result)
         else:
-            print('No result found for ' + searchText)
+            print("No result found for " + searchText)
             return None
 
     except Exception:
@@ -585,16 +588,16 @@ def isValidComment(comment):
     Roboragi and the parent commenter isn't Roboragi)
     """
     try:
-        if (DatabaseHandler.commentExists(comment.id)):
+        if DatabaseHandler.commentExists(comment.id):
             return False
 
         try:
-            if (comment.author.name == USERNAME):
+            if comment.author.name == USERNAME:
                 DatabaseHandler.addComment(
                     commentid=comment.id,
                     requester=comment.author.name,
                     subreddit=comment.subreddit,
-                    hadRequest=False
+                    hadRequest=False,
                 )
                 return False
         except Exception:

--- a/roboragi/VNDB.py
+++ b/roboragi/VNDB.py
@@ -25,14 +25,14 @@ import traceback
 
 import Config
 
-cache = {'get': []}
+cache = {"get": []}
 cachetime = 720  # cache stuff for 12 minutes
 
 username = Config.vndbuser
 password = Config.vndbpassword
 
-client_name = 'RoboragiRedditBot'
-client_version = '1.0'
+client_name = "RoboragiRedditBot"
+client_version = "1.0"
 client_protocol = 1
 
 
@@ -42,11 +42,12 @@ class vndbException(Exception):
 
 class VNDB(object):
     """ Python interface for vndb's api (vndb.org), featuring cache """
+
     protocol = 1
 
     def __init__(self):
         self.sock = socket.socket()
-        self.sock.connect(('api.vndb.org', 19534))
+        self.sock.connect(("api.vndb.org", 19534))
 
         login_args = dict(
             protocol=client_protocol,
@@ -54,11 +55,11 @@ class VNDB(object):
             clientver=float(client_version),
         )
 
-        self.sendCommand('login', login_args)
+        self.sendCommand("login", login_args)
 
         res = self.getRawResponse()
-        if res.find('error ') == 0:
-            msg = json.loads(' '.join(res.split(' ')[1:]))['msg']
+        if res.find("error ") == 0:
+            msg = json.loads(" ".join(res.split(" ")[1:]))["msg"]
             raise vndbException(msg)
 
     def close(self):
@@ -72,20 +73,16 @@ class VNDB(object):
         >>> results['items'][0]['image']
         u'http://s.vndb.org/cv/99/4599.jpg'
         """
-        args = '{0} {1} {2} {3}'.format(type, flags, filters, options)
-        for item in cache['get']:
-            item_query = item['query']
-            cached_time = item['time'] + cachetime
+        args = "{0} {1} {2} {3}".format(type, flags, filters, options)
+        for item in cache["get"]:
+            item_query = item["query"]
+            cached_time = item["time"] + cachetime
             if item_query == args and time.time() < cached_time:
-                return item['results']
+                return item["results"]
 
-        self.sendCommand('get', args)
+        self.sendCommand("get", args)
         res = self.getResponse()[1]
-        cache['get'].append(dict(
-            time=time.time(),
-            query=args,
-            results=res
-        ))
+        cache["get"].append(dict(time=time.time(), query=args, results=res))
         return res
 
     def sendCommand(self, command, args=None):
@@ -94,14 +91,14 @@ class VNDB(object):
         Example
         >>> self.sendCommand('test', {'this is an': 'argument'})
         """
-        whole = ''
+        whole = ""
         whole += command.lower()
         if isinstance(args, str):
-            whole += ' ' + args
+            whole += " " + args
         elif isinstance(args, dict):
-            whole += ' ' + json.dumps(args)
+            whole += " " + json.dumps(args)
 
-        self.sock.send('{0}\x04'.format(whole).encode())
+        self.sock.send("{0}\x04".format(whole).encode())
 
     def getResponse(self):
         """
@@ -113,16 +110,16 @@ class VNDB(object):
         ('ok', {'test': 0})
         """
         res = self.getRawResponse()
-        cmdname = res.split(' ')[0]
-        if len(res.split(' ')) > 1:
-            args = json.loads(' '.join(res.split(' ')[1:]))
+        cmdname = res.split(" ")[0]
+        if len(res.split(" ")) > 1:
+            args = json.loads(" ".join(res.split(" ")[1:]))
 
-        if cmdname == 'error':
-            if args['id'] == 'throttled':
-                msg = 'Throttled, limit of 100 commands per 10 minutes'
+        if cmdname == "error":
+            if args["id"] == "throttled":
+                msg = "Throttled, limit of 100 commands per 10 minutes"
                 raise vndbException(msg)
             else:
-                raise vndbException(args['msg'])
+                raise vndbException(args["msg"])
         return (cmdname, args)
 
     def getRawResponse(self):
@@ -134,98 +131,94 @@ class VNDB(object):
         'ok {"test": 0}'
         """
         finished = False
-        whole = ''
+        whole = ""
         while not finished:
             whole += self.sock.recv(4096).decode()
-            if '\x04' in whole:
+            if "\x04" in whole:
                 finished = True
-        return whole.replace('\x04', '').strip()
+        return whole.replace("\x04", "").strip()
 
     def parseResults(self, results):
         parsed_results = []
-        for result in results['items']:
+        for result in results["items"]:
             try:
-                id_ = result['id']
-                title = result['title']
+                id_ = result["id"]
+                title = result["title"]
                 url = f"https://vndb.org/v{id_}"
-                description = result['description']
-                length = self.parseLength(result['length'])
+                description = result["description"]
+                length = self.parseLength(result["length"])
 
-                if result['aliases']:
-                    synonyms = result['aliases'].split('\n')
+                if result["aliases"]:
+                    synonyms = result["aliases"].split("\n")
                 else:
                     synonyms = []
 
-                wikipedia = result['links']['wikipedia']
+                wikipedia = result["links"]["wikipedia"]
                 if wikipedia:
                     wikipedia_url = f"https://wikipedia.org/wiki/{wikipedia}"
                 else:
                     wikipedia_url = None
 
-                if result['released']:
-                    released = result['released'][:4]
+                if result["released"]:
+                    released = result["released"][:4]
                 else:
                     released = None
 
-                parsed_results.append(dict(
-                    id=id_,
-                    title=title,
-                    synonyms=synonyms,
-                    url=url,
-                    wikipedia_url=wikipedia_url,
-                    description=description,
-                    length=length,
-                    release_year=released,
-                ))
+                parsed_results.append(
+                    dict(
+                        id=id_,
+                        title=title,
+                        synonyms=synonyms,
+                        url=url,
+                        wikipedia_url=wikipedia_url,
+                        description=description,
+                        length=length,
+                        release_year=released,
+                    )
+                )
             except Exception:
                 traceback.print_exc()
         return parsed_results
 
     def parseLength(self, length):
         if length == 1:
-            return 'Very Short'
+            return "Very Short"
         elif length == 2:
-            return 'Short'
+            return "Short"
         elif length == 3:
-            return 'Medium'
+            return "Medium"
         elif length == 4:
-            return 'Long'
+            return "Long"
         elif length == 5:
-            return 'Very Long'
-        return 'Unknown'
+            return "Very Long"
+        return "Unknown"
 
     def getClosest(self, searchText, listOfVNs):
-        titleList = [vn['title'].lower() for vn in listOfVNs if vn['title']]
+        titleList = [vn["title"].lower() for vn in listOfVNs if vn["title"]]
 
         closestFromTitles = difflib.get_close_matches(
-            word=searchText.lower(),
-            possibilities=titleList,
-            n=1,
-            cutoff=0.95
+            word=searchText.lower(), possibilities=titleList, n=1, cutoff=0.95
         )
 
         if closestFromTitles:
             titleToFind = closestFromTitles[0]
             for vn in listOfVNs:
-                if vn['title'].lower() == titleToFind:
+                if vn["title"].lower() == titleToFind:
                     return vn
 
         synonymList = []
         for vn in listOfVNs:
-            for synonym in vn['synonyms']:
+            for synonym in vn["synonyms"]:
                 synonymList.append(synonym.lower())
 
         closestFromSynonyms = difflib.get_close_matches(
-            word=searchText.lower(),
-            possibilities=synonymList,
-            n=1,
-            cutoff=0.95
+            word=searchText.lower(), possibilities=synonymList, n=1, cutoff=0.95
         )
 
         if closestFromSynonyms:
             synonymToFind = closestFromSynonyms[0]
             for vn in listOfVNs:
-                synonyms = [synonym.lower() for synonym in vn['synonyms']]
+                synonyms = [synonym.lower() for synonym in vn["synonyms"]]
                 if synonymToFind.lower() in synonyms:
                     return vn
 
@@ -234,10 +227,10 @@ class VNDB(object):
     def getVisualNovelDetails(self, searchText):
         try:
             results = self.get(
-                type='vn',
-                flags='basic,details',
+                type="vn",
+                flags="basic,details",
                 filters='(search~"{0}")'.format(searchText),
-                options=''
+                options="",
             )
             parsed_results = self.parseResults(results)
             closest = self.getClosest(searchText, parsed_results)
@@ -250,10 +243,10 @@ class VNDB(object):
     def getVisualNovelDetailsById(self, id):
         try:
             results = self.get(
-                type='vn',
-                flags='basic,details',
+                type="vn",
+                flags="basic,details",
                 filters='(id="{0}")'.format(str(id)),
-                options=''
+                options="",
             )
             parsed_results = self.parseResults(results)
 

--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,24 @@
 from setuptools import setup, find_packages
 
 install_requires = [
-    'praw==5.4.0',
-    'psycopg2-binary==2.7.5',
-    'pyquery==1.4.0',
-    'requests==2.19.1',
-    'six==1.10.0',
+    "praw==5.4.0",
+    "psycopg2-binary==2.7.5",
+    "pyquery==1.4.0",
+    "requests==2.19.1",
+    "six==1.10.0",
 ]
 
-dev_requires = [
-    'flake8',
-    'pytest',
-    'pytest-cov',
-]
+dev_requires = ["flake8", "pytest", "pytest-cov"]
 
 setup(
-    name='roboragi',
-    author='Nihilate',
-    url='https://github.com/Nihilate/Roboragi',
-    license='AGPLv3+',
+    name="roboragi",
+    author="Nihilate",
+    url="https://github.com/Nihilate/Roboragi",
+    license="AGPLv3+",
     install_requires=install_requires,
     packages=find_packages(),
-    extras_require={
-        'dev': dev_requires,
-    },
+    extras_require={"dev": dev_requires},
     classifiers=[
-        'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
-    ]
+        "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)"
+    ],
 )

--- a/tests/test_kitsu.py
+++ b/tests/test_kitsu.py
@@ -21,61 +21,50 @@ from roboragi.Kitsu import (
     get_title_by_language_codes,
     ENGLISH_LANGUAGE_CODES,
     ROMAJI_LANGUAGE_CODES,
-    JAPANESE_LANGUAGE_CODES
+    JAPANESE_LANGUAGE_CODES,
 )
 
-BRITISH_ENGLISH_TITLES = dict(en='British English Title')
-AMERICAN_ENGLISH_TITLES = dict(en_us='American English Title')
+BRITISH_ENGLISH_TITLES = dict(en="British English Title")
+AMERICAN_ENGLISH_TITLES = dict(en_us="American English Title")
 ALL_ENGLISH_TITLES = dict(**BRITISH_ENGLISH_TITLES, **AMERICAN_ENGLISH_TITLES)
 
-ROMAJI_TITLES = dict(en_jp='Rōmaji Title')
-JAPANESE_TITLES = dict(ja_jp='日本のタイトル')
+ROMAJI_TITLES = dict(en_jp="Rōmaji Title")
+JAPANESE_TITLES = dict(ja_jp="日本のタイトル")
 
-ALL_LANGUAGE_TITLES = dict(
-    **ALL_ENGLISH_TITLES,
-    **ROMAJI_TITLES,
-    **JAPANESE_TITLES,
-)
+ALL_LANGUAGE_TITLES = dict(**ALL_ENGLISH_TITLES, **ROMAJI_TITLES, **JAPANESE_TITLES)
 
 
 def test_get_synonyms_dedupes_synonyms():
-    given = dict(synonyms=[
-        'Samurai Champloo',
-        'Samurai Champloo',
-        'One Punch Man',
-        'One Punch Man'
-    ])
-    expected = set(('Samurai Champloo', 'One Punch Man'))
+    given = dict(
+        synonyms=[
+            "Samurai Champloo",
+            "Samurai Champloo",
+            "One Punch Man",
+            "One Punch Man",
+        ]
+    )
+    expected = set(("Samurai Champloo", "One Punch Man"))
 
     assert get_synonyms(result=given) == expected
 
 
 def test_get_titles_dedupes_titles():
-    given = dict(
-        title_english='Samurai Champloo',
-        title_romaji='Samurai Champloo',
-    )
-    expected = set(('Samurai Champloo',))
+    given = dict(title_english="Samurai Champloo", title_romaji="Samurai Champloo")
+    expected = set(("Samurai Champloo",))
 
     assert get_titles(result=given) == expected
 
 
 def test_get_titles_can_ignore_missing_english_titles():
-    given = dict(
-        title_english=None,
-        title_romaji='Samurai Champloo'
-    )
-    expected = set(('Samurai Champloo',))
+    given = dict(title_english=None, title_romaji="Samurai Champloo")
+    expected = set(("Samurai Champloo",))
 
     assert get_titles(result=given) == expected
 
 
 def test_get_titles_can_ignore_missing_romaji_titles():
-    given = dict(
-        title_english='Samurai Champloo',
-        title_romaji=None,
-    )
-    expected = set(('Samurai Champloo',))
+    given = dict(title_english="Samurai Champloo", title_romaji=None)
+    expected = set(("Samurai Champloo",))
 
     assert get_titles(result=given) == expected
 
@@ -87,40 +76,56 @@ def test_get_titles_returns_empty_set_with_no_titles():
     assert get_titles(result=given) == expected
 
 
-@pytest.mark.parametrize('language_codes,titles,expected', [
-    (ENGLISH_LANGUAGE_CODES, BRITISH_ENGLISH_TITLES, BRITISH_ENGLISH_TITLES['en']),  # noqa: E501
-    (ENGLISH_LANGUAGE_CODES, AMERICAN_ENGLISH_TITLES, AMERICAN_ENGLISH_TITLES['en_us']),  # noqa: E501
-    (ROMAJI_LANGUAGE_CODES, ROMAJI_TITLES, ROMAJI_TITLES['en_jp']),
-    (JAPANESE_LANGUAGE_CODES, JAPANESE_TITLES, JAPANESE_TITLES['ja_jp']),
-])
+@pytest.mark.parametrize(
+    "language_codes,titles,expected",
+    [
+        (
+            ENGLISH_LANGUAGE_CODES,
+            BRITISH_ENGLISH_TITLES,
+            BRITISH_ENGLISH_TITLES["en"],
+        ),  # noqa: E501
+        (
+            ENGLISH_LANGUAGE_CODES,
+            AMERICAN_ENGLISH_TITLES,
+            AMERICAN_ENGLISH_TITLES["en_us"],
+        ),  # noqa: E501
+        (ROMAJI_LANGUAGE_CODES, ROMAJI_TITLES, ROMAJI_TITLES["en_jp"]),
+        (JAPANESE_LANGUAGE_CODES, JAPANESE_TITLES, JAPANESE_TITLES["ja_jp"]),
+    ],
+)
 def test_title_extraction_single_titles(language_codes, titles, expected):
     actual = get_title_by_language_codes(titles, language_codes)
     assert actual == expected
 
 
-@pytest.mark.parametrize('language_codes,titles,expected', [
-    (ENGLISH_LANGUAGE_CODES, ALL_LANGUAGE_TITLES, ALL_LANGUAGE_TITLES['en']),
-    (ROMAJI_LANGUAGE_CODES, ALL_LANGUAGE_TITLES, ALL_LANGUAGE_TITLES['en_jp']),
-    (JAPANESE_LANGUAGE_CODES, ALL_LANGUAGE_TITLES, ALL_LANGUAGE_TITLES['ja_jp']),  # noqa: E501
-])
+@pytest.mark.parametrize(
+    "language_codes,titles,expected",
+    [
+        (ENGLISH_LANGUAGE_CODES, ALL_LANGUAGE_TITLES, ALL_LANGUAGE_TITLES["en"]),
+        (ROMAJI_LANGUAGE_CODES, ALL_LANGUAGE_TITLES, ALL_LANGUAGE_TITLES["en_jp"]),
+        (
+            JAPANESE_LANGUAGE_CODES,
+            ALL_LANGUAGE_TITLES,
+            ALL_LANGUAGE_TITLES["ja_jp"],
+        ),  # noqa: E501
+    ],
+)
 def test_title_extraction_multiple_titles(language_codes, titles, expected):
     actual = get_title_by_language_codes(titles, language_codes)
     assert actual == expected
 
 
-@pytest.mark.parametrize('language_codes', [
-    ENGLISH_LANGUAGE_CODES,
-    ROMAJI_LANGUAGE_CODES,
-    JAPANESE_LANGUAGE_CODES,
-])
+@pytest.mark.parametrize(
+    "language_codes",
+    [ENGLISH_LANGUAGE_CODES, ROMAJI_LANGUAGE_CODES, JAPANESE_LANGUAGE_CODES],
+)
 def test_title_extraction_no_titles(language_codes):
     assert get_title_by_language_codes({}, language_codes) is None
 
 
 def test_title_extraction_prefers_british_over_american_english():
-    expected = ALL_ENGLISH_TITLES['en']
+    expected = ALL_ENGLISH_TITLES["en"]
     actual = get_title_by_language_codes(
-        titles=ALL_ENGLISH_TITLES,
-        language_codes=ENGLISH_LANGUAGE_CODES
+        titles=ALL_ENGLISH_TITLES, language_codes=ENGLISH_LANGUAGE_CODES
     )
     assert actual == expected

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -18,275 +18,303 @@ import pytest
 from roboragi.patterns import find_requests
 
 
-@pytest.mark.parametrize('given,expected', [
-    ('{K}', ['K']),
-    ('{Bakemonogatari}', ['Bakemonogatari']),
-    ('{Steins;Gate}', ['Steins;Gate']),
-    ('{Kill la Kill}', ['Kill la Kill']),
-    ('{ヒナまつり}', ['ヒナまつり']),
-    ('{Re:Zero} {No Game No Life}', ['Re:Zero', 'No Game No Life']),
-    ('{Gunbuster}, {Diebuster}', ['Gunbuster', 'Diebuster']),
-    ('{Nisekoi}: Words Go Here', ['Nisekoi']),
-    ('', []),
-    ('{}', []),
-    ('{ }', []),
-    ('{  }', []),
-    ('{trailing_whitespace }', []),
-    ('{ leading_whitespace}', []),
-    ('{ wrapping_whitespace }', []),
-    ('words{before}', []),
-    ('**{bold_markdown}**', ['bold_markdown']),
-    ('{{extended}}', []),
-    ('{{partial_before}', []),
-    ('{partial_after}}', []),
-    ('{nested{after}}', []),
-    ('{{nested}before}', []),
-])
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("{K}", ["K"]),
+        ("{Bakemonogatari}", ["Bakemonogatari"]),
+        ("{Steins;Gate}", ["Steins;Gate"]),
+        ("{Kill la Kill}", ["Kill la Kill"]),
+        ("{ヒナまつり}", ["ヒナまつり"]),
+        ("{Re:Zero} {No Game No Life}", ["Re:Zero", "No Game No Life"]),
+        ("{Gunbuster}, {Diebuster}", ["Gunbuster", "Diebuster"]),
+        ("{Nisekoi}: Words Go Here", ["Nisekoi"]),
+        ("", []),
+        ("{}", []),
+        ("{ }", []),
+        ("{  }", []),
+        ("{trailing_whitespace }", []),
+        ("{ leading_whitespace}", []),
+        ("{ wrapping_whitespace }", []),
+        ("words{before}", []),
+        ("**{bold_markdown}**", ["bold_markdown"]),
+        ("{{extended}}", []),
+        ("{{partial_before}", []),
+        ("{partial_after}}", []),
+        ("{nested{after}}", []),
+        ("{{nested}before}", []),
+    ],
+)
 def test_regular_anime(given, expected):
-    actual = list(find_requests('anime', given))
+    actual = list(find_requests("anime", given))
     assert actual == expected
 
 
-@pytest.mark.parametrize('given,expected', [
-    ('{{K}}', ['K']),
-    ('{{Bakemonogatari}}', ['Bakemonogatari']),
-    ('{{Steins;Gate}}', ['Steins;Gate']),
-    ('{{Kill la Kill}}', ['Kill la Kill']),
-    ('{{ヒナまつり}}', ['ヒナまつり']),
-    ('{{Re:Zero}} {{No Game No Life}}', ['Re:Zero', 'No Game No Life']),
-    ('{{Gunbuster}}, {{Diebuster}}', ['Gunbuster', 'Diebuster']),
-    ('{{Nisekoi}}: Words Go Here', ['Nisekoi']),
-    ('', []),
-    ('{{}}', []),
-    ('{{ }}', []),
-    ('{{  }}', []),
-    ('{{trailing_whitespace }}', []),
-    ('{{ leading_whitespace}}', []),
-    ('{{ wrapping_whitespace }}', []),
-    ('words{{before}}', []),
-    ('**{{bold_markdown}}**', ['bold_markdown']),
-    ('{regular}', []),
-    ('{{{{partial_before}}', []),
-    ('{{partial_after}}}}', []),
-    ('{{nested{{after}}}}', []),
-    ('{{{{nested}}before}}}', []),
-])
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("{{K}}", ["K"]),
+        ("{{Bakemonogatari}}", ["Bakemonogatari"]),
+        ("{{Steins;Gate}}", ["Steins;Gate"]),
+        ("{{Kill la Kill}}", ["Kill la Kill"]),
+        ("{{ヒナまつり}}", ["ヒナまつり"]),
+        ("{{Re:Zero}} {{No Game No Life}}", ["Re:Zero", "No Game No Life"]),
+        ("{{Gunbuster}}, {{Diebuster}}", ["Gunbuster", "Diebuster"]),
+        ("{{Nisekoi}}: Words Go Here", ["Nisekoi"]),
+        ("", []),
+        ("{{}}", []),
+        ("{{ }}", []),
+        ("{{  }}", []),
+        ("{{trailing_whitespace }}", []),
+        ("{{ leading_whitespace}}", []),
+        ("{{ wrapping_whitespace }}", []),
+        ("words{{before}}", []),
+        ("**{{bold_markdown}}**", ["bold_markdown"]),
+        ("{regular}", []),
+        ("{{{{partial_before}}", []),
+        ("{{partial_after}}}}", []),
+        ("{{nested{{after}}}}", []),
+        ("{{{{nested}}before}}}", []),
+    ],
+)
 def test_expanded_anime(given, expected):
-    actual = list(find_requests('anime', given, expanded=True))
+    actual = list(find_requests("anime", given, expanded=True))
     assert actual == expected
 
 
-@pytest.mark.parametrize('given,expected', [
-    ('<K>', ['K']),
-    ('<Bakemonogatari>', ['Bakemonogatari']),
-    ('<Steins;Gate>', ['Steins;Gate']),
-    ('<Kill la Kill>', ['Kill la Kill']),
-    ('<ヒナまつり>', ['ヒナまつり']),
-    ('<Re:Zero> <No Game No Life>', ['Re:Zero', 'No Game No Life']),
-    ('<Gunbuster>, <Diebuster>', ['Gunbuster', 'Diebuster']),
-    ('<Nisekoi>: Words Go Here', ['Nisekoi']),
-    ('', []),
-    ('<>', []),
-    ('< >', []),
-    ('<  >', []),
-    ('<trailing_whitespace >', []),
-    ('< leading_whitespace>', []),
-    ('< wrapping_whitespace >', []),
-    ('words<before>', []),
-    ('**<bold_markdown>**', ['bold_markdown']),
-    ('<<extended>>', []),
-    ('<<partial_before>', []),
-    ('<partial_after>>', []),
-    ('<nested<after>>', []),
-    ('<<nested>before>', []),
-])
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("<K>", ["K"]),
+        ("<Bakemonogatari>", ["Bakemonogatari"]),
+        ("<Steins;Gate>", ["Steins;Gate"]),
+        ("<Kill la Kill>", ["Kill la Kill"]),
+        ("<ヒナまつり>", ["ヒナまつり"]),
+        ("<Re:Zero> <No Game No Life>", ["Re:Zero", "No Game No Life"]),
+        ("<Gunbuster>, <Diebuster>", ["Gunbuster", "Diebuster"]),
+        ("<Nisekoi>: Words Go Here", ["Nisekoi"]),
+        ("", []),
+        ("<>", []),
+        ("< >", []),
+        ("<  >", []),
+        ("<trailing_whitespace >", []),
+        ("< leading_whitespace>", []),
+        ("< wrapping_whitespace >", []),
+        ("words<before>", []),
+        ("**<bold_markdown>**", ["bold_markdown"]),
+        ("<<extended>>", []),
+        ("<<partial_before>", []),
+        ("<partial_after>>", []),
+        ("<nested<after>>", []),
+        ("<<nested>before>", []),
+    ],
+)
 def test_regular_manga(given, expected):
-    actual = list(find_requests('manga', given))
+    actual = list(find_requests("manga", given))
     assert actual == expected
 
 
-@pytest.mark.parametrize('given,expected', [
-    ('<<K>>', ['K']),
-    ('<<Bakemonogatari>>', ['Bakemonogatari']),
-    ('<<Steins;Gate>>', ['Steins;Gate']),
-    ('<<Kill la Kill>>', ['Kill la Kill']),
-    ('<<ヒナまつり>>', ['ヒナまつり']),
-    ('<<Re:Zero>> <<No Game No Life>>', ['Re:Zero', 'No Game No Life']),
-    ('<<Gunbuster>>, <<Diebuster>>', ['Gunbuster', 'Diebuster']),
-    ('<<Nisekoi>>: Words Go Here', ['Nisekoi']),
-    ('', []),
-    ('<<>>', []),
-    ('<< >>', []),
-    ('<<  >>', []),
-    ('<<trailing_whitespace >>', []),
-    ('<< leading_whitespace>>', []),
-    ('<< wrapping_whitespace >>', []),
-    ('words<<before>>', []),
-    ('**<<bold_markdown>>**', ['bold_markdown']),
-    ('<regular>', []),
-    ('<<<<partial_before>>', []),
-    ('<<partial_after>>>>', []),
-    ('<<nested<<after>>>>', []),
-    ('<<<<nested>>before>>', []),
-])
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("<<K>>", ["K"]),
+        ("<<Bakemonogatari>>", ["Bakemonogatari"]),
+        ("<<Steins;Gate>>", ["Steins;Gate"]),
+        ("<<Kill la Kill>>", ["Kill la Kill"]),
+        ("<<ヒナまつり>>", ["ヒナまつり"]),
+        ("<<Re:Zero>> <<No Game No Life>>", ["Re:Zero", "No Game No Life"]),
+        ("<<Gunbuster>>, <<Diebuster>>", ["Gunbuster", "Diebuster"]),
+        ("<<Nisekoi>>: Words Go Here", ["Nisekoi"]),
+        ("", []),
+        ("<<>>", []),
+        ("<< >>", []),
+        ("<<  >>", []),
+        ("<<trailing_whitespace >>", []),
+        ("<< leading_whitespace>>", []),
+        ("<< wrapping_whitespace >>", []),
+        ("words<<before>>", []),
+        ("**<<bold_markdown>>**", ["bold_markdown"]),
+        ("<regular>", []),
+        ("<<<<partial_before>>", []),
+        ("<<partial_after>>>>", []),
+        ("<<nested<<after>>>>", []),
+        ("<<<<nested>>before>>", []),
+    ],
+)
 def test_expanded_manga(given, expected):
-    actual = list(find_requests('manga', given, expanded=True))
+    actual = list(find_requests("manga", given, expanded=True))
     assert actual == expected
 
 
-@pytest.mark.parametrize('given,expected', [
-    (']K[', ['K']),
-    (']Bakemonogatari[', ['Bakemonogatari']),
-    (']Steins;Gate[', ['Steins;Gate']),
-    (']Kill la Kill[', ['Kill la Kill']),
-    (']ヒナまつり[', ['ヒナまつり']),
-    (']Re:Zero[ ]No Game No Life[', ['Re:Zero', 'No Game No Life']),
-    (']Gunbuster[, ]Diebuster[', ['Gunbuster', 'Diebuster']),
-    (']Nisekoi[: Words Go Here', ['Nisekoi']),
-    ('', []),
-    ('][', []),
-    ('] [', []),
-    (']  [', []),
-    (']trailing_whitespace [', []),
-    ('] leading_whitespace[', []),
-    ('] wrapping_whitespace [', []),
-    ('words]before[', []),
-    ('**]bold_markdown[**', ['bold_markdown']),
-    (']]extended[[', []),
-    (']]partial_before[', []),
-    (']partial_after[[', []),
-    (']nested]after[[', []),
-    (']]nested[before[', []),
-])
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("]K[", ["K"]),
+        ("]Bakemonogatari[", ["Bakemonogatari"]),
+        ("]Steins;Gate[", ["Steins;Gate"]),
+        ("]Kill la Kill[", ["Kill la Kill"]),
+        ("]ヒナまつり[", ["ヒナまつり"]),
+        ("]Re:Zero[ ]No Game No Life[", ["Re:Zero", "No Game No Life"]),
+        ("]Gunbuster[, ]Diebuster[", ["Gunbuster", "Diebuster"]),
+        ("]Nisekoi[: Words Go Here", ["Nisekoi"]),
+        ("", []),
+        ("][", []),
+        ("] [", []),
+        ("]  [", []),
+        ("]trailing_whitespace [", []),
+        ("] leading_whitespace[", []),
+        ("] wrapping_whitespace [", []),
+        ("words]before[", []),
+        ("**]bold_markdown[**", ["bold_markdown"]),
+        ("]]extended[[", []),
+        ("]]partial_before[", []),
+        ("]partial_after[[", []),
+        ("]nested]after[[", []),
+        ("]]nested[before[", []),
+    ],
+)
 def test_regular_light_novel(given, expected):
-    actual = list(find_requests('light_novel', given))
+    actual = list(find_requests("light_novel", given))
     assert actual == expected
 
 
-@pytest.mark.parametrize('given,expected', [
-    (']]K[[', ['K']),
-    (']]Bakemonogatari[[', ['Bakemonogatari']),
-    (']]Steins;Gate[[', ['Steins;Gate']),
-    (']]Kill la Kill[[', ['Kill la Kill']),
-    (']]ヒナまつり[[', ['ヒナまつり']),
-    (']]Re:Zero[[ ]]No Game No Life[[', ['Re:Zero', 'No Game No Life']),
-    (']]Gunbuster[[, ]]Diebuster[[', ['Gunbuster', 'Diebuster']),
-    (']]Nisekoi[[: Words Go Here', ['Nisekoi']),
-    ('', []),
-    (']][[', []),
-    (']] [[', []),
-    (']]  [[', []),
-    (']]trailing_whitespace [[', []),
-    (']] leading_whitespace[[', []),
-    (']] wrapping_whitespace [[', []),
-    ('words]]before[[', []),
-    ('**]]bold_markdown[[**', ['bold_markdown']),
-    (']regular[', []),
-    (']]]]partial_before[[', []),
-    (']]partial_after[[[[', []),
-    (']]nested]]after[[[[', []),
-    (']]]]nested[[before[[', []),
-])
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("]]K[[", ["K"]),
+        ("]]Bakemonogatari[[", ["Bakemonogatari"]),
+        ("]]Steins;Gate[[", ["Steins;Gate"]),
+        ("]]Kill la Kill[[", ["Kill la Kill"]),
+        ("]]ヒナまつり[[", ["ヒナまつり"]),
+        ("]]Re:Zero[[ ]]No Game No Life[[", ["Re:Zero", "No Game No Life"]),
+        ("]]Gunbuster[[, ]]Diebuster[[", ["Gunbuster", "Diebuster"]),
+        ("]]Nisekoi[[: Words Go Here", ["Nisekoi"]),
+        ("", []),
+        ("]][[", []),
+        ("]] [[", []),
+        ("]]  [[", []),
+        ("]]trailing_whitespace [[", []),
+        ("]] leading_whitespace[[", []),
+        ("]] wrapping_whitespace [[", []),
+        ("words]]before[[", []),
+        ("**]]bold_markdown[[**", ["bold_markdown"]),
+        ("]regular[", []),
+        ("]]]]partial_before[[", []),
+        ("]]partial_after[[[[", []),
+        ("]]nested]]after[[[[", []),
+        ("]]]]nested[[before[[", []),
+    ],
+)
 def test_expanded_light_novel(given, expected):
-    actual = list(find_requests('light_novel', given, expanded=True))
+    actual = list(find_requests("light_novel", given, expanded=True))
     assert actual == expected
 
 
-@pytest.mark.parametrize('given,expected', [
-    ('|K|', ['K']),
-    ('|Bakemonogatari|', ['Bakemonogatari']),
-    ('|Steins;Gate|', ['Steins;Gate']),
-    ('|Kill la Kill|', ['Kill la Kill']),
-    ('|ヒナまつり|', ['ヒナまつり']),
-    ('|Re:Zero| |No Game No Life|', ['Re:Zero', 'No Game No Life']),
-    ('|Gunbuster|, |Diebuster|', ['Gunbuster', 'Diebuster']),
-    ('|Nisekoi|: Words Go Here', ['Nisekoi']),
-    ('', []),
-    ('||', []),
-    ('| |', []),
-    ('|  |', []),
-    ('|trailing_whitespace |', []),
-    ('| leading_whitespace|', []),
-    ('| wrapping_whitespace |', []),
-    ('words|before|', []),
-    ('**|bold_markdown|**', ['bold_markdown']),
-    ('||extended||', []),
-    ('||partial_before|', []),
-    ('|partial_after||', []),
-    ('|nested|after||', []),
-    ('||nested|before|', []),
-])
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("|K|", ["K"]),
+        ("|Bakemonogatari|", ["Bakemonogatari"]),
+        ("|Steins;Gate|", ["Steins;Gate"]),
+        ("|Kill la Kill|", ["Kill la Kill"]),
+        ("|ヒナまつり|", ["ヒナまつり"]),
+        ("|Re:Zero| |No Game No Life|", ["Re:Zero", "No Game No Life"]),
+        ("|Gunbuster|, |Diebuster|", ["Gunbuster", "Diebuster"]),
+        ("|Nisekoi|: Words Go Here", ["Nisekoi"]),
+        ("", []),
+        ("||", []),
+        ("| |", []),
+        ("|  |", []),
+        ("|trailing_whitespace |", []),
+        ("| leading_whitespace|", []),
+        ("| wrapping_whitespace |", []),
+        ("words|before|", []),
+        ("**|bold_markdown|**", ["bold_markdown"]),
+        ("||extended||", []),
+        ("||partial_before|", []),
+        ("|partial_after||", []),
+        ("|nested|after||", []),
+        ("||nested|before|", []),
+    ],
+)
 def test_regular_visual_novel(given, expected):
-    actual = list(find_requests('visual_novel', given))
+    actual = list(find_requests("visual_novel", given))
     assert actual == expected
 
 
-@pytest.mark.parametrize('given,expected', [
-    ('||K||', ['K']),
-    ('||Bakemonogatari||', ['Bakemonogatari']),
-    ('||Steins;Gate||', ['Steins;Gate']),
-    ('||Kill la Kill||', ['Kill la Kill']),
-    ('||ヒナまつり||', ['ヒナまつり']),
-    ('||Re:Zero|| ||No Game No Life||', ['Re:Zero', 'No Game No Life']),
-    ('||Gunbuster||, ||Diebuster||', ['Gunbuster', 'Diebuster']),
-    ('||Nisekoi||: Words Go Here', ['Nisekoi']),
-    ('', []),
-    ('||||', []),
-    ('|| ||', []),
-    ('||  ||', []),
-    ('||trailing_whitespace ||', []),
-    ('|| leading_whitespace||', []),
-    ('|| wrapping_whitespace ||', []),
-    ('words||before||', []),
-    ('**||bold_markdown||**', ['bold_markdown']),
-    ('|regular|', []),
-    ('||||partial_before||', []),
-    ('||partial_after||||', []),
-    ('||nested||after||||', []),
-    ('||||nested||before||', []),
-])
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("||K||", ["K"]),
+        ("||Bakemonogatari||", ["Bakemonogatari"]),
+        ("||Steins;Gate||", ["Steins;Gate"]),
+        ("||Kill la Kill||", ["Kill la Kill"]),
+        ("||ヒナまつり||", ["ヒナまつり"]),
+        ("||Re:Zero|| ||No Game No Life||", ["Re:Zero", "No Game No Life"]),
+        ("||Gunbuster||, ||Diebuster||", ["Gunbuster", "Diebuster"]),
+        ("||Nisekoi||: Words Go Here", ["Nisekoi"]),
+        ("", []),
+        ("||||", []),
+        ("|| ||", []),
+        ("||  ||", []),
+        ("||trailing_whitespace ||", []),
+        ("|| leading_whitespace||", []),
+        ("|| wrapping_whitespace ||", []),
+        ("words||before||", []),
+        ("**||bold_markdown||**", ["bold_markdown"]),
+        ("|regular|", []),
+        ("||||partial_before||", []),
+        ("||partial_after||||", []),
+        ("||nested||after||||", []),
+        ("||||nested||before||", []),
+    ],
+)
 def test_expanded_visual_novel(given, expected):
-    actual = list(find_requests('visual_novel', given, expanded=True))
+    actual = list(find_requests("visual_novel", given, expanded=True))
     assert actual == expected
 
 
 def test_all_regular_patterns():
-    given = ('This is an **example** [Markdown](https://commonmark.org/)\n'
-             'comment. Here are some requests:\n'
-             '{anime 1} {anime2}\n'
-             '<manga 1> <manga2>\n'
-             ']light novel 1[ ]light_novel2[\n'
-             '|visual novel 1| |visual_novel2|\n')
+    given = (
+        "This is an **example** [Markdown](https://commonmark.org/)\n"
+        "comment. Here are some requests:\n"
+        "{anime 1} {anime2}\n"
+        "<manga 1> <manga2>\n"
+        "]light novel 1[ ]light_novel2[\n"
+        "|visual novel 1| |visual_novel2|\n"
+    )
     expected = [
-        'anime 1',
-        'anime2',
-        'manga 1',
-        'manga2',
-        'light novel 1',
-        'light_novel2',
-        'visual novel 1',
-        'visual_novel2',
+        "anime 1",
+        "anime2",
+        "manga 1",
+        "manga2",
+        "light novel 1",
+        "light_novel2",
+        "visual novel 1",
+        "visual_novel2",
     ]
-    actual = list(find_requests('all', given))
+    actual = list(find_requests("all", given))
     assert actual == expected
 
 
 def test_all_extended_patterns():
-    given = ('This is an **example** [Markdown](https://commonmark.org/)\n'
-             'comment. Here are some requests:\n'
-             '{{anime 1}} {{anime2}}\n'
-             '<<manga 1>> <<manga2>>\n'
-             ']]light novel 1[[ ]]light_novel2[[\n'
-             '||visual novel 1|| ||visual_novel2||\n')
+    given = (
+        "This is an **example** [Markdown](https://commonmark.org/)\n"
+        "comment. Here are some requests:\n"
+        "{{anime 1}} {{anime2}}\n"
+        "<<manga 1>> <<manga2>>\n"
+        "]]light novel 1[[ ]]light_novel2[[\n"
+        "||visual novel 1|| ||visual_novel2||\n"
+    )
     expected = [
-        'anime 1',
-        'anime2',
-        'manga 1',
-        'manga2',
-        'light novel 1',
-        'light_novel2',
-        'visual novel 1',
-        'visual_novel2',
+        "anime 1",
+        "anime2",
+        "manga 1",
+        "manga2",
+        "light novel 1",
+        "light_novel2",
+        "visual novel 1",
+        "visual_novel2",
     ]
-    actual = list(find_requests('all', given, expanded=True))
+    actual = list(find_requests("all", given, expanded=True))
     assert actual == expected


### PR DESCRIPTION
@Nihilate: This PR should address #73 by applying [Black](https://black.readthedocs.io/en/stable/) to all the relevant Python code. It looks like a lot of changes, but it's mostly just exchanging `'` for `"` and reflowing some code.

I'd like to include running Black in the CI pipeline so that future PRs are required to follow the same formatting, but it's not obvious to me how I should configure that. Happy to add it myself if you can point me in the right direction, otherwise I'd recommend you include running it like this
```shell
black --verbose --check roboragi tests
```
to validate both the application and the tests. :grin: 