### PR TITLE
Add type annotations to AnimePlanet.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,8 @@ oauth.ini
 .idea
 
 .pytest_cache/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json

--- a/roboragi/AnimePlanet.py
+++ b/roboragi/AnimePlanet.py
@@ -15,9 +15,10 @@
 
 import difflib
 from sys import version_info
+from typing import Optional
 
 import requests
-from pyquery import PyQuery as pq
+from pyquery import PyQuery as pq  # type: ignore
 
 PY2 = version_info == 2
 
@@ -33,11 +34,11 @@ BASE_URL = "https://www.anime-planet.com"
 req = requests.Session()
 
 
-def sanitiseSearchText(searchText):
+def sanitiseSearchText(searchText: str) -> str:
     return searchText.replace('(TV)', 'TV')
 
 
-def getAnimeURL(searchText):
+def getAnimeURL(searchText: str):
     try:
         searchText = sanitiseSearchText(searchText)
 
@@ -102,7 +103,7 @@ def getAnimeURL(searchText):
         return None
 
 
-def getMangaURL(searchText, authorName=None):
+def getMangaURL(searchText: str, authorName: str = None) -> Optional[str]:
     """
     Probably doesn't need to be split into two functions given how similar they
     are, but it might be worth keeping separate for the sake of issues between
@@ -171,9 +172,9 @@ def getMangaURL(searchText, authorName=None):
         return None
 
 
-def getAnimeURLById(animeId):
+def getAnimeURLById(animeId: str) -> str:
     return 'https://www.anime-planet.com/anime/' + str(animeId)
 
 
-def getMangaURLById(mangaId):
+def getMangaURLById(mangaId: str) -> str:
     return 'https://www.anime-planet.com/manga/' + str(mangaId)


### PR DESCRIPTION
I had a little bit of extra time this evening, so I thought I'd take a crack at addressing a _trivial_ part of #52. This just adds type annotations for `roboragi/AnimePlanet.py` and puts some known `mypy` files into the `.gitignore`.

There were a few types that seemed ambiguous that I guessed at (like the `animeId` and `mangaId` arguments which come from a table in the SQLite database that I don't think has an explicit schema) and the `authorName` variable, which I don't think is actually used by any calling code. If I've erred in assessing those types just let me know and I can adjust.

I should also note that in contrast to #75, this only adds type annotations on function signatures. I'm not sure if you'd prefer to add them everywhere, but I'll be happy to adjust that to your preference as well, @Nihilate. Myself, I tend to only add them on the function signatures and where there's ambiguity that `mypy` complains about.

#### Running `mypy` against `roboragi/AnimePlanet.py` after these changes
```
[19:29:10] venv:(roboragi) tucker@khanti:~/Projects/Roboragi git:(enhancement/type-annotations) § mypy roboragi/AnimePlanet.py                   
Success: no issues found in 1 source file
[19:29:20] venv:(roboragi) tucker@khanti:~/Projects/Roboragi git:(enhancement/type-annotations) §
```